### PR TITLE
Trigger Operator

### DIFF
--- a/interface/ComposableSelector.h
+++ b/interface/ComposableSelector.h
@@ -147,7 +147,7 @@ template <class EventClass> bool  ComposableSelector<EventClass>::Process(Long64
 {
 
   n_entries++;
-  if ((n_entries%((int)tot_entries/5)) == 0) std::cout << "processing " << n_entries << " entry" << std::endl; 
+  if ((n_entries%((int)tot_entries/3)) == 0) std::cout << "processing " << n_entries << " entry" << std::endl; 
 
   // set TTreeReader entry
   reader_.SetLocalEntry(entry);

--- a/interface/TriggerOperator.h
+++ b/interface/TriggerOperator.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "BaseOperator.h"
+
+template <class EventClass> class TriggerOperator : public BaseOperator<EventClass> {
+
+  public:
+
+    std::vector<std::string> or_paths_; 
+
+    TriggerOperator(std::vector<std::string> or_paths) :
+      or_paths_(or_paths) {}
+    virtual ~TriggerOperator() {}
+
+    virtual bool process( EventClass & ev ) {
+      for (const auto & or_path : or_paths_) {
+        for (std::size_t i=0; i<ev.hlt_bits_reader_.size(); i++) {
+          if (ev.hlt_bits_.at(i).first==or_path) {
+            if (ev.hlt_bits_.at(i).second) return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    virtual std::string get_name() {
+      auto name = std::string{};
+      name+= "trigger";
+      for (const auto & or_path : or_paths_) name+="_OR"+or_path; 
+      return name;
+    }
+
+};

--- a/python/samplelists.py
+++ b/python/samplelists.py
@@ -1,4 +1,5 @@
 
+# lists of samples to be processed. Insert the proper label in the config file.
 
 samlists = {
 

--- a/python/triggerlists.py
+++ b/python/triggerlists.py
@@ -1,0 +1,21 @@
+
+# lists of trigger paths to be used to select events (logical OR). Insert the proper label in the config file.
+# warning: square bracket and "" are compulsory.
+
+triggerlists = {
+
+   ''  : [], #null lists
+
+   'def_2016'       : [ "HLT_QuadJet45_TripleBTagCSV_p087_v",
+                        "HLT_DoubleJet90_Double30_TripleBTagCSV_p087_v" ],
+
+   'prescaled_2016' : [ "HLT_DoubleJet90_Double30_DoubleBTagCSV_p087_v",
+                        "HLT_QuadJet45_DoubleBTagCSV_p087_v" ],
+
+   'singleMu_2016'  : [ "HLT_BIT_HLT_IsoMu18_v" ],
+
+   'others_2016'  : [ "HLT_BIT_HLT_IsoMu20_v",
+                      "HLT_BIT_HLT_IsoMu22_v",
+                      "HLT_BIT_HLT_Mu27_v" ],
+
+}

--- a/src/classes.h
+++ b/src/classes.h
@@ -3,6 +3,7 @@
 #include "Analysis/alp_analysis/interface/ComposableSelector.h"
 #include "Analysis/alp_analysis/interface/BaseOperator.h"
 #include "Analysis/alp_analysis/interface/CounterOperator.h"
+#include "Analysis/alp_analysis/interface/TriggerOperator.h"
 #include "Analysis/alp_analysis/interface/JetFilterOperator.h"
 #include "Analysis/alp_analysis/interface/BTagFilterOperator.h"
 #include "Analysis/alp_analysis/interface/JetPairingOperator.h"
@@ -19,6 +20,7 @@ namespace {
     ComposableSelector<EventBase> composable_selector; 
     BaseOperator<EventBase> base_operator; 
     CounterOperator<EventBase> counter_operator; 
+    TriggerOperator<EventBase> trigger_operator; 
     JetFilterOperator<EventBase> jet_filter_operator; 
     BTagFilterOperator<EventBase> b_tag_filter_operator; 
     JetPairingOperator<EventBase> jet_pairing_operator; 

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -2,10 +2,11 @@
   <class name="alp::Event"/>    
   <class pattern="ComposableSelector*"/>    
   <class pattern="CounterOperator<*>"/>    
+  <class pattern="TriggerOperator<*>"/>    
   <class pattern="JetFilterOperator<*>"/>    
   <class pattern="BTagFilterOperator<*>"/>    
   <class pattern="JetPairingOperator<*>"/>    
   <class pattern="SetJetPairingOperator<*>"/>    
   <class pattern="DiJetPlotterOperator<*>"/>    
-  <class pattern="EventWriterOperator<*>"/>    
+  <class pattern="EventWriterOperator<*>"/> 
 </lcgdict>  


### PR DESCRIPTION
Trigger Operator implemented by looking at hh2bbbb code.
Idea is to store various trigger lists in a .py file and just call one combination in the config script.
Important: the lists contains the trigger paths used in TriggerOperator (logical OR).

Trigger selection is applied only if TriggerOperator is added to the Selector.
The trigger lists is always passed to the config_ .
(Pablo, check if the new operator is properly implemented).
