### PR TITLE
add FolderOperator and change output folder design

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="roottmva"/>
 <use name="rootminuit2"/> 
 <use name="rootmath"/>
-<use name="analysis/ALPHA"/>
+<use name="Analysis/ALPHA"/>
 <flags CXXFLAGS="-lGenVector"/>
 <Flags ROOTMAP="no"/>
 <export>

--- a/interface/ComposableSelector.h
+++ b/interface/ComposableSelector.h
@@ -125,11 +125,19 @@ template <class EventClass> void ComposableSelector<EventClass>::SlaveBegin(TTre
 
    tfile_ = new TFile(o_filename.c_str(), "RECREATE");
  
+   // output folder handling
    auto root_dir = dynamic_cast<TDirectory *>(&(*tfile_));
+   // use root by default
    auto curr_dir = root_dir;
    for (auto & op : ops_) {
      auto name = op->get_name();
-     if (name != "") curr_dir = curr_dir->mkdir(name.c_str());
+     // if operator name is starts with folder_ use subsequent string 
+     // as a name of the folder where to save further output
+     if (name.find("folder_") == 0) {
+      auto folder_name = name.substr(7);
+      curr_dir = root_dir->mkdir(folder_name.c_str());
+      if (curr_dir == nullptr) curr_dir = root_dir;
+     }
      op->init(curr_dir);
    }
 

--- a/interface/DiJetPlotterOperator.h
+++ b/interface/DiJetPlotterOperator.h
@@ -13,8 +13,6 @@ template <class EventClass> class DiJetPlotterOperator : public BaseOperator<Eve
   public:
  
     std::vector<std::string> weights_;
-    bool root_;
-    std::string dir_;
 
     TH1D h_H0_mass {"h_H0_mass", "", 300, 0., 900.};
     TH1D h_H0_mass_unc_sq {"h_H0_mass_unc_sq", "", 300, 0., 900.};
@@ -33,22 +31,12 @@ template <class EventClass> class DiJetPlotterOperator : public BaseOperator<Eve
     TH1D h_H0H1_mass {"h_H0H1_mass", "", 300, 0., 900.};
     TH1D h_H0H1_mass_unc_sq {"h_H0H1_mass_unc_sq", "", 300, 0., 900.};
 
-     DiJetPlotterOperator(const std::vector<std::string> & weights = {}, bool root = false, std::string dir = ""  ) :
-      weights_(weights),
-      root_(root),
-      dir_(dir) {}
+     DiJetPlotterOperator(const std::vector<std::string> & weights = {}) :
+      weights_(weights) {}
     virtual ~DiJetPlotterOperator() {}
 
     virtual void init(TDirectory * tdir) {
-      if (root_) {
-        tdir = tdir->GetFile();
-        auto ndir = tdir->mkdir(dir_.c_str());
-        if (ndir == 0) {
-          tdir = tdir->GetDirectory(dir_.c_str());
-        } else {
-          tdir = ndir;
-        }
-      }
+
       h_H0_mass.SetDirectory(tdir);
       h_H0_pt.SetDirectory(tdir);
       h_H0_eta.SetDirectory(tdir);

--- a/interface/FolderOperator.h
+++ b/interface/FolderOperator.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "BaseOperator.h"
+
+template <class EventClass> class FolderOperator : public BaseOperator<EventClass> {
+
+  public:
+
+    std::string folder_name_;
+
+    FolderOperator(std::string folder_name) :
+      folder_name_(folder_name) {}
+    virtual ~FolderOperator() {}
+
+    virtual std::string get_name() {
+      auto name = std::string("folder_")+folder_name_;
+      return name;
+    }
+
+};

--- a/interface/JetPlotterOperator.h
+++ b/interface/JetPlotterOperator.h
@@ -14,8 +14,6 @@ template <class EventClass> class JetPlotterOperator : public BaseOperator<Event
  
     std::string disc_;
     std::vector<std::string> weights_;
-    bool root_;
-    std::string dir_;
     std::vector<std::size_t> j_sortInd_;
 
     TH1D h_jets_ht {"h_jets_ht", "", 300, 0., 900.};
@@ -40,23 +38,13 @@ template <class EventClass> class JetPlotterOperator : public BaseOperator<Event
     TH1D h_jet3_csv_unc_sq {"h_jet3_csv_unc_sq", "", 300,  -12., 1.};
 
 
-     JetPlotterOperator(std::string disc, const std::vector<std::string> & weights = {}, bool root = false, std::string dir = ""  ) :
+     JetPlotterOperator(std::string disc, const std::vector<std::string> & weights = {}) :
       disc_(disc),
-      weights_(weights),
-      root_(root),
-      dir_(dir) {}
+      weights_(weights) {}
     virtual ~JetPlotterOperator() {}
 
     virtual void init(TDirectory * tdir) {
-      if (root_) {
-        tdir = tdir->GetFile();
-        auto ndir = tdir->mkdir(dir_.c_str());
-        if (ndir == 0) {
-          tdir = tdir->GetDirectory(dir_.c_str());
-        } else {
-          tdir = ndir;
-        }
-      }
+
       h_jets_ht.SetDirectory(tdir);
       h_jet0_pt.SetDirectory(tdir);
       h_jet0_eta.SetDirectory(tdir);

--- a/scripts/ComposableSelector.py
+++ b/scripts/ComposableSelector.py
@@ -5,7 +5,7 @@ import json
 from ROOT import TChain
 # custom ROOT classes 
 from ROOT import alp, ComposableSelector, CounterOperator, JetFilterOperator, BTagFilterOperator, JetPairingOperator, DiJetPlotterOperator
-from ROOT import BaseOperator, EventWriterOperator
+from ROOT import BaseOperator, FolderOperator, EventWriterOperator
 
 
 config = {"jets_branch_name": "Jets",
@@ -18,10 +18,13 @@ selector.addOperator(JetFilterOperator(alp.Event)(2.5, 30., 4))
 selector.addOperator(CounterOperator(alp.Event)())
 selector.addOperator(BTagFilterOperator(alp.Event)("pfCombinedInclusiveSecondaryVertexV2BJetTags", 0.800, 4))
 selector.addOperator(CounterOperator(alp.Event)())
+selector.addOperator(FolderOperator(alp.Event)("empty_one"))
 selector.addOperator(JetPairingOperator(alp.Event)(4))
+selector.addOperator(FolderOperator(alp.Event)("4CSVM"))
 selector.addOperator(DiJetPlotterOperator(alp.Event)())
 selector.addOperator(CounterOperator(alp.Event)())
 selector.addOperator(EventWriterOperator(alp.Event)())
+selector.addOperator(FolderOperator(alp.Event)("empty_two"))
 
 tchain = TChain("ntuple/tree")
 tchain.Add("/lustre/cmswork/hh/alpha_ntuples/v0_20161004/GluGluToHHTo4B_node_SM_13TeV-madgraph_v14-v1/0000/output.root")

--- a/src/classes.h
+++ b/src/classes.h
@@ -2,6 +2,7 @@
 #include "Analysis/alp_analysis/interface/Event.h"
 #include "Analysis/alp_analysis/interface/ComposableSelector.h"
 #include "Analysis/alp_analysis/interface/BaseOperator.h"
+#include "Analysis/alp_analysis/interface/FolderOperator.h"
 #include "Analysis/alp_analysis/interface/CounterOperator.h"
 #include "Analysis/alp_analysis/interface/TriggerOperator.h"
 #include "Analysis/alp_analysis/interface/JetFilterOperator.h"
@@ -23,6 +24,7 @@ namespace {
     EventBase event_base; 
     ComposableSelector<EventBase> composable_selector; 
     BaseOperator<EventBase> base_operator; 
+    FolderOperator<EventBase> folder_operator; 
     CounterOperator<EventBase> counter_operator; 
     TriggerOperator<EventBase> trigger_operator; 
     JetFilterOperator<EventBase> jet_filter_operator; 

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   <class name="alp::Event"/>    
   <class pattern="ComposableSelector*"/>    
+  <class pattern="FolderOperator<*>"/>    
   <class pattern="CounterOperator<*>"/>    
   <class pattern="TriggerOperator<*>"/>    
   <class pattern="JetFilterOperator<*>"/>    


### PR DESCRIPTION
A new operator has to be manually added so the output of the ComposableSelector
is kept in a subfolder, the parameter of the constructor of FolderOpertator
is used as the folder name.

First attempt to fix issue #3, by requiring to manually specify the subfolders. Also simplified Jet /DiJet PlotterOperator code.
