### PR TITLE
example of a JIT operator (LiveOperator.h) for simple use cases

### DIFF
--- a/scripts/LiveOperator.h
+++ b/scripts/LiveOperator.h
@@ -1,0 +1,50 @@
+
+#pragma once
+
+#include <algorithm>
+
+#include "TH1.h"
+#include "TH2.h"
+
+#include "../interface/BaseOperator.h"
+
+template <class EventClass> class LiveOperator : public BaseOperator<EventClass> {
+
+  public:
+ 
+    // member are all data (e.g. histograms, vectors that
+    // have to be kept and filled for each event)
+    
+    TH1D h_jets_pt {"h_jets_pt", "", 300, 0., 900.};
+
+     LiveOperator() {}
+    virtual ~LiveOperator() {}
+
+    // done before processing any event
+    virtual void init(TDirectory * tdir) {
+
+      // this is required so histograms are saved in
+      // the output file
+      h_jets_pt.SetDirectory(tdir);
+
+      h_jets_pt.Sumw2();
+
+    }
+
+    // done for each event (passed as a reference)
+    virtual bool process( EventClass & ev ) {
+
+      for (const auto & jet : ev.jets_) {
+        h_jets_pt.Fill(jet.pt());
+      }
+
+      return true;
+    }
+
+    // done at the end (e.g. save output) 
+    virtual bool output( TFile * tfile) {
+
+      return true;
+    }
+
+};

--- a/scripts/LiveOperator.h
+++ b/scripts/LiveOperator.h
@@ -5,6 +5,7 @@
 
 #include "TH1.h"
 #include "TH2.h"
+#include "TCanvas.h"
 
 #include "../interface/BaseOperator.h"
 
@@ -41,8 +42,13 @@ template <class EventClass> class LiveOperator : public BaseOperator<EventClass>
       return true;
     }
 
-    // done at the end (e.g. save output) 
+    // done at the end (e.g. save output or create/draw canvas) 
     virtual bool output( TFile * tfile) {
+
+      TCanvas c1("c1");
+      c1.cd();
+      h_jets_pt.Draw();
+      c1.Write();
 
       return true;
     }

--- a/scripts/SimpleSelector.py
+++ b/scripts/SimpleSelector.py
@@ -7,6 +7,7 @@ import importlib
 from glob import glob
 
 # ROOT imports
+import ROOT
 from ROOT import TChain, TH1F, TFile, vector, gROOT
 # custom ROOT classes 
 from ROOT import alp, ComposableSelector

--- a/scripts/SimpleSelector.py
+++ b/scripts/SimpleSelector.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python 
+
+# good old python modules
+import json
+import os
+import importlib
+from glob import glob
+
+# ROOT imports
+from ROOT import TChain, TH1F, TFile, vector, gROOT
+# custom ROOT classes 
+from ROOT import alp, ComposableSelector
+
+TH1F.AddDirectory(0)
+
+# imports from ../python 
+from Analysis.alp_analysis.alpSamples  import samples
+from Analysis.alp_analysis.samplelists import samlists
+from Analysis.alp_analysis.triggerlists import triggerlists
+
+
+# exe parameters
+numEvents  = 1000       # -1 to process all (10000)
+samList    = {'trigger'}   # list of samples to be processed - append multiple lists , 'data', 'mainbkg'    , 'datall', 'mainbkg', 'minortt', 'dibosons', 'bosons','trigger'
+trgList    = 'singleMu_2016'
+trgListN   = 'def_2016'
+intLumi_fb = 12.6          # data integrated luminosity
+
+iDir       = '/lustre/cmswork/hh/alpha_ntuples/'
+ntuplesVer = 'v0_20161004'         # equal to ntuple's folder
+oDir       = './output/v0_Simple'         # output dir ('./test')
+operator_file = "LiveOperator.h"
+# ---------------
+
+if not os.path.exists(oDir): os.mkdir(oDir)
+
+trg_names = triggerlists[trgList]
+trg_namesN = triggerlists[trgListN]
+trg_names.extend(trg_namesN) #to pass all triggers in config
+if not trg_names: print "### WARNING: empty hlt_names ###"
+trg_names_v = vector("string")()
+for trg_name in trg_names: trg_names_v.push_back(trg_name)
+trg_namesN_v = vector("string")()
+for trg_nameN in trg_namesN: trg_namesN_v.push_back(trg_nameN)
+
+# to parse variables to the anlyzer
+config = {"jets_branch_name": "Jets",
+          "hlt_names": trg_names, 
+          "n_gen_events":0,
+          "xsec_br" : 0,
+          "matcheff": 0,
+          "kfactor" : 0,
+          "isData" : False,
+          "lumiFb" : intLumi_fb,
+         }
+
+snames = []
+for s in samList:
+    snames.extend(samlists[s])
+
+# process samples
+ns = 0
+hcount = TH1F('hcount', 'num of genrated events',1,0,1)
+for sname in snames:
+    isHLT = False
+
+    #get file names in all sub-folders:
+    files = glob(iDir+ntuplesVer+"/"+samples[sname]["sam_name"]+"/*/output.root")
+    print "\n ### processing {}".format(sname)        
+ 
+    #preliminary checks
+    if not files: 
+        print "WARNING: files do not exist"
+        continue
+    else:
+        if "Run" in files[0]: config["isData"] = True 
+        elif "_v14" in files[0]: isHLT = True #patch - check better way to look for HLT
+        else:
+            print "WARNING: no HLT, skip samples"
+            continue
+
+    #read counters to get generated eventsbj
+    ngenev = 0
+    for f in files:
+        tf = TFile(f)
+        hcount.Add(tf.Get('counter/c_nEvents'))
+        tf.Close()
+    ngenev = hcount.GetBinContent(1)
+    config["n_gen_events"]=ngenev
+    print  "gen numEv {}".format(ngenev)
+
+    #read weights from alpSamples 
+    config["xsec_br"]  = samples[sname]["xsec_br"]
+    config["matcheff"] = samples[sname]["matcheff"]
+    config["kfactor"]  = samples[sname]["kfactor"]
+
+    # load the operator
+    gROOT.ProcessLine("#include \"{}\"".format(operator_file))
+    operator_name = os.path.splitext(os.path.basename(operator_file))[0]
+    Operator = importlib.import_module("ROOT.{}".format(operator_name))
+
+    # define selectors list
+    selector = ComposableSelector(alp.Event)(0, json.dumps(config))
+    selector.addOperator(Operator(alp.Event)())
+
+    #create tChain and process each files
+    tchain = TChain("ntuple/tree")
+    for File in files:                     
+        tchain.Add(File)       
+    nev = numEvents if (numEvents > 0 and numEvents < tchain.GetEntries()) else tchain.GetEntries()
+    procOpt = "ofile=./"+sname+".root" if not oDir else "ofile="+oDir+"/"+sname+".root"
+    print "max numEv {}".format(nev)
+    tchain.Process(selector, procOpt, nev)
+    ns+=1
+   
+    #some cleaning
+    hcount.Reset()
+
+print "### processed {} samples ###".format(ns) 


### PR DESCRIPTION
It is loaded at runtime, but has the same structure than the
full analysis operator so it can be integrated at a later point.

To run it, I have a create a simple Python script based
on the trigger one, nevertheless it can be adapted to
the needs of the users (or even do the same with a ROOT
macro, but I do no see the need).

Basically you can modify LiveOperator.h (or copy it and change
operator_name in the python script) and it will be automatically
loaded and used to process all events. Maybe in the future it would
be good to have arguments in the python script so you could do something
like:

```
python SimpleSelector.py --operator LiveOperator.h --max_events 1000
```
