### PR TITLE
Event mixing modules and syncronice input/output

### DIFF
--- a/interface/Event.h
+++ b/interface/Event.h
@@ -7,6 +7,7 @@
 #include "Analysis/ALPHA/interface/alp_objects.h"
 // includes from this repositoty
 #include "json.hpp"
+#include "Hemisphere.h"
 
 // for convenience
 using json = nlohmann::json;
@@ -30,6 +31,10 @@ namespace alp {
       // additional stuff that might be created during the processing 
       std::vector<PtEtaPhiEVector> dijets_;
       std::vector<std::size_t> free_is_;
+      // to save the hemispheres (rotated and pz positive)
+      std::vector<alp::Hemisphere> hems_; 
+      // best matching hemispheres ( [first/second][proximity])
+      std::vector<std::vector<alp::Hemisphere>> best_match_hems_; 
   
       // TTreeReaderValue/Array pointers (so they are nullable) to get the data 
       TTreeReaderValue<std::vector<alp::Jet>> * jets_reader_ = nullptr;
@@ -37,6 +42,9 @@ namespace alp {
       TTreeReaderArray<float> * muons_pt_reader_ = nullptr;
       TTreeReaderArray<float> * muons_pfiso03_reader_ = nullptr;
       TTreeReaderValue<float> * met_pt_reader_ = nullptr;
+
+      // to keep the tranverse thrust axis phi
+      double thrust_phi_ = -10.;
   
       Event() {}
       Event(TTreeReader & reader, const json & config = {}) {
@@ -89,6 +97,10 @@ namespace alp {
 
         // met information
         met_pt_ = **met_pt_reader_;
+
+        thrust_phi_ = -10;
+        hems_.clear();
+        best_match_hems_.clear();
 
       }
   

--- a/interface/EventWriterOperator.h
+++ b/interface/EventWriterOperator.h
@@ -5,37 +5,59 @@
 #include <math.h>
 
 #include "BaseOperator.h"
+#include "json.hpp"
+
+// for convenience
+using json = nlohmann::json;
 
 template <class EventClass> class EventWriterOperator : public BaseOperator<EventClass> {
 
   public:
  
-    bool root_;
-    std::string dir_;
-
-    // variables to save in branches
+    // save in branches what was read
+    alp::EventInfo * eventInfo_ptr = nullptr;
     std::vector<alp::Jet> * jets_ptr = nullptr;
+    std::vector<alp::Lepton> * muons_ptr = nullptr;
+    std::vector<alp::Lepton> * electrons_ptr = nullptr;
+    alp::Candidate * met_ptr = nullptr;
+
+    // additional stuff to save
     std::vector<alp::PtEtaPhiEVector> * dijets_ptr = nullptr;
 
+    TTree tree_{"tree","Tree using simplified alp dataformats"};
 
-    TTree tree_{"tree","Tree using simplified mut::dataformats"};
+    json config_ = {};
 
-     EventWriterOperator(bool root = false, std::string dir = "") :
-      root_(root),
-      dir_(dir) {}
+    EventWriterOperator(const json & config) :
+      config_(config) {}
     virtual ~EventWriterOperator() {}
 
     virtual void init(TDirectory * tdir) {
-      if (root_) {
-        tdir = tdir->GetFile();
-        auto ndir = tdir->mkdir(dir_.c_str());
-        if (ndir == 0) {
-          tdir = tdir->GetDirectory(dir_.c_str());
-        } else {
-          tdir = ndir;
-        }
+
+      if (config_.find("eventInfo_branch_name") != config_.end()) {
+        tree_.Branch(config_.at("eventInfo_branch_name").template get<std::string>().c_str(),
+                     "alp::EventInfo", &eventInfo_ptr, 64000, 2);
       }
-      tree_.Branch("Jets","std::vector<alp::Jet>",&jets_ptr, 64000, 2);
+      if (config_.find("jets_branch_name") != config_.end()) {
+        tree_.Branch(config_.at("jets_branch_name").template get<std::string>().c_str(),
+                     "std::vector<alp::Jet>",&jets_ptr, 64000, 2);
+      }
+      // load muon collection
+      if (config_.find("muons_branch_name") != config_.end()) {
+        tree_.Branch(config_.at("muons_branch_name").template get<std::string>().c_str(),      
+                     "std::vector<alp::Lepton>",&muons_ptr, 64000, 2);
+      }                                                                               
+      // load electron collection
+      if (config_.find("electrons_branch_name") != config_.end()) {
+        tree_.Branch(config_.at("electrons_branch_name").template get<std::string>().c_str(),
+                     "std::vector<alp::Lepton>",&electrons_ptr, 64000, 2);
+      }                                                                               
+      // load MET 
+      if (config_.find("met_branch_name") != config_.end()) {
+        tree_.Branch(config_.at("met_branch_name").template get<std::string>().c_str(),
+                     "std::vector<alp::Candidate>",&met_ptr, 64000, 2);
+      }                                                                               
+
       tree_.Branch("DiJets","std::vector<alp::PtEtaPhiEVector>", &dijets_ptr, 64000, 2);
 
 
@@ -48,8 +70,14 @@ template <class EventClass> class EventWriterOperator : public BaseOperator<Even
     virtual bool process( EventClass & ev ) {
 
 
-      // to fill tree redirect pointers
+      // to fill tree redirect pointers that where read
+      eventInfo_ptr = dynamic_cast<alp::EventInfo *>(&ev.eventInfo_); 
       jets_ptr = dynamic_cast<std::vector<alp::Jet> *>(&ev.jets_); 
+      muons_ptr = dynamic_cast<std::vector<alp::Lepton> *>(&ev.muons_); 
+      electrons_ptr = dynamic_cast<std::vector<alp::Lepton> *>(&ev.electrons_); 
+      met_ptr = dynamic_cast<alp::Candidate *>(&ev.met_); 
+
+      // also other event stuff
       dijets_ptr = dynamic_cast<std::vector<alp::PtEtaPhiEVector> *>(&ev.dijets_); 
 
       tree_.Fill();

--- a/interface/Hemisphere.h
+++ b/interface/Hemisphere.h
@@ -1,0 +1,103 @@
+
+#pragma once
+
+#define _USE_MATH_DEFINES
+
+#include "Event.h"
+
+#include "Math/GenVector/VectorUtil.h"
+
+namespace alp { 
+  class Hemisphere { 
+    public:
+  
+      std::vector<alp::Jet> jets_;
+  
+      double p_phi_ = 0.;
+      bool sumPz_inv_ = false;
+      bool d_phi_inv_ = false;
+  
+      Hemisphere() {}
+      Hemisphere(double p_phi, bool d_phi_inv ) : 
+        p_phi_(p_phi),
+        d_phi_inv_(d_phi_inv) {}
+  
+      virtual ~Hemisphere() {}                   
+  
+  
+      static double sumPz(const Hemisphere & hem) {
+        double sumPz = 0.0;
+        for (const auto & j : hem.jets_) {
+          sumPz += j.p4_.Pz();
+        }
+        return sumPz;
+      }
+  
+      static double thrustMayor(const Hemisphere & hem) {
+        double thrustMayor = 0.0;
+        for (const auto & j : hem.jets_) {
+          double d_phi = ROOT::Math::VectorUtil::Phi_mpi_pi(j.p4_.Phi()-M_PI/2.);
+          thrustMayor += std::abs(j.p4_.Pt()* std::cos(d_phi));
+        }
+        return thrustMayor;
+      }
+  
+      static double thrustMinor(const Hemisphere & hem) {
+        double thrustMinor = 0.0;
+        for (const auto & j : hem.jets_) {
+          double d_phi = ROOT::Math::VectorUtil::Phi_mpi_pi(j.p4_.Phi()-M_PI/2.);
+          thrustMinor += std::abs(j.p4_.Pt()* std::sin(d_phi));
+        }
+        return thrustMinor;
+      }
+  
+      static double invMass(const Hemisphere & hem) {
+        alp::PtEtaPhiEVector sum_v; // init null?
+        for (const auto & j : hem.jets_) {
+          sum_v += j.p4_;
+        }
+        return sum_v.M();
+      }
+  
+      static int nJets(const Hemisphere & hem) {
+        return int(hem.jets_.size());
+      }
+  
+      static int nTags(const Hemisphere & hem,
+                       std::string disc = "pfCombinedInclusiveSecondaryVertexV2BJetTags",
+                       float wp = 0.8) {
+        int nTags = 0;
+        for (const auto & j : hem.jets_) {
+          if (j.disc(disc) > wp) nTags++;
+        }
+        return nTags;
+      }
+  
+  
+      double getSumPz() {
+        return sumPz(*this);
+      }
+  
+      double getThrustMayor() {
+        return thrustMayor(*this);
+      }
+     
+      double getThrustMinor() {
+        return thrustMinor(*this);
+      }
+  
+      double getInvMass() {
+        return invMass(*this);
+      }
+  
+      int getNJets() {
+        return nJets(*this);
+      }
+  
+      int getNTags(std::string disc = "pfCombinedInclusiveSecondaryVertexV2BJetTags", float wp = 0.8) {
+        return nTags(*this,disc,wp);
+      }
+  
+  };
+
+}

--- a/interface/HemisphereMixerOperator.h
+++ b/interface/HemisphereMixerOperator.h
@@ -1,0 +1,294 @@
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <math.h>
+#include <cmath>
+
+#include "TChain.h"
+#include "TTreeReader.h"
+#include "TTreeReaderValue.h"
+#include "TEntryList.h"
+
+#include "BaseOperator.h"
+#include "Hemisphere.h"
+#include "nanoflann.hpp"
+#include "prettyprint.hpp"
+
+
+// class to hold variables for NN search
+class HemisphereLibrary {
+
+  public:
+
+    typedef std::function<double(const alp::Hemisphere &)> FuncD;
+    typedef std::vector<std::function<double(const alp::Hemisphere &)>> FuncDVec;
+    typedef std::vector<alp::Hemisphere> HemVec;
+
+    std::size_t n_vars_;
+    std::size_t n_points_;
+    std::vector<std::vector<double>> vars_v_;
+    std::vector<double> sum_;
+    std::vector<double> sumsq_;
+    std::vector<double> var_stds_; 
+
+    HemisphereLibrary(const HemVec & hem_v, const FuncDVec & funcDVec) :
+      n_vars_(funcDVec.size()),
+      n_points_(hem_v.size()),
+      sum_(n_vars_, 0.0),
+      sumsq_(n_vars_, 0.0) {
+      for (auto hem : hem_v) {
+        vars_v_.emplace_back(n_vars_, 0.0); // add n_vars elements
+        for (std::size_t i=0; i < n_vars_; i++) {
+          const auto & funcD = funcDVec.at(i);
+          vars_v_.back().at(i) = funcD(hem);
+          sum_.at(i) =  vars_v_.back().at(i);
+          sumsq_.at(i) = std::pow(vars_v_.back().at(i),2);
+        }
+      }
+    }
+
+    virtual ~HemisphereLibrary() {}
+
+    std::vector<double> & get_sum() { return sum_;}
+    std::vector<double> & get_sumsq() { return sumsq_;}
+    std::size_t get_n_points() { return n_points_;}
+
+    void scale_vars_by_subset_stds() {
+		
+        for (std::size_t i=0; i < n_vars_; i++) {
+					double mu = sum_.at(i)/n_points_;
+					double x2 = sumsq_.at(i)/n_points_;
+          double var = x2-mu*mu;
+          for (std::size_t p = 0; p < n_points_; p++) {
+						var_stds_.emplace_back(std::sqrt(var)); 
+					}
+				}
+
+        scale_vars_by_stds(var_stds_);
+
+    }
+
+    void scale_vars_by_stds(const std::vector<double> var_stds) {
+
+        for (std::size_t i=0; i < n_vars_; i++) {
+          for (std::size_t p = 0; p < n_points_; p++) {
+						vars_v_.at(p).at(i) /= var_stds.at(i); //divide by std
+					}
+				}
+		}
+
+    // Must return the number of data points
+    inline size_t kdtree_get_point_count() const { return n_points_; }
+
+    // L2 distance between p1 and and point with index idx_p2 
+    inline double kdtree_distance(const double *p1,
+                                  const size_t idx_p2,size_t /*size*/) const {
+      double distance = 0.0;
+      for (std::size_t i=0; i < n_vars_; i++) {
+        distance += std::pow(p1[i] - vars_v_[idx_p2][i], 2);
+      }
+      return distance;
+    }
+
+    // Returns the dim'th component of the idx'th point 
+    inline double kdtree_get_pt(const size_t idx, int dim) const {
+      return vars_v_[idx][dim];
+    }
+
+    template <class BBOX>
+    bool kdtree_get_bbox(BBOX& /*bb*/) const { return false; }
+
+};
+
+enum class Scaling {none, subset, set};
+
+template <class EventClass> class HemisphereMixerOperator : public BaseOperator<EventClass> {
+
+  public:
+ 
+    typedef std::function<int(const alp::Hemisphere &)> FuncI;
+    typedef std::vector<std::function<int(const alp::Hemisphere &)>> FuncIVec;
+    typedef std::function<double(const alp::Hemisphere &)> FuncD;
+    typedef std::vector<std::function<double(const alp::Hemisphere &)>> FuncDVec;
+    typedef std::vector<alp::Hemisphere> HemVec;
+    typedef std::vector<int> IntVec;
+    // construct a kd-tree index:
+	  typedef nanoflann::KDTreeSingleIndexAdaptor<
+            	nanoflann::L2_Simple_Adaptor<double, HemisphereLibrary>,
+		          HemisphereLibrary > my_kd_tree_t;
+
+    // map of vectors of hemipsheres (key is integer category) 
+    std::map<IntVec, HemVec> hem_m_; 
+    std::map<IntVec, HemisphereLibrary> hem_lib_; 
+    // vector of functions  to compute distances 
+    FuncIVec funcIVec_;
+    FuncDVec funcDVec_;
+		// map of kd-trees
+    std::map<IntVec, std::unique_ptr<my_kd_tree_t>> index_m_;
+    // scaling mode
+    Scaling scaling_;
+    // variances (global)
+   	std::vector<double> var_stds_;
+    // number of neighbours to keep for each hemisphere
+    std::size_t knn_;
+
+    HemisphereMixerOperator( TChain * tc_hm,
+                     FuncIVec funcIVec = { FuncI( [] (const alp::Hemisphere & hem) {
+                                            int nJets = alp::Hemisphere::nJets(hem);
+                                            return ( nJets > 3 ? 4 : nJets);
+                                          }),
+                                          FuncI( [] (const alp::Hemisphere & hem) {
+                                            int nTags = alp::Hemisphere::nTags(hem, "CSV", 0.8);
+                                            return ( nTags > 3 ? 4 : nTags);
+                                          })},
+                     FuncDVec funcDVec = { FuncD(&alp::Hemisphere::thrustMayor),
+                                           FuncD(&alp::Hemisphere::thrustMinor),
+                                           FuncD(&alp::Hemisphere::sumPz),
+                                           FuncD(&alp::Hemisphere::invMass)},
+                     Scaling scaling = Scaling::set,
+                     std::size_t knn = 10) :
+      funcIVec_(funcIVec),
+      funcDVec_(funcDVec),
+      scaling_(scaling),
+      var_stds_(funcDVec_.size(), 0.0),
+      knn_(knn) {
+
+      // setup readers  
+      TTreeReader hem_reader(tc_hm);
+      TTreeReaderValue<std::vector<alp::Hemisphere>> hems(hem_reader, "hems");
+      auto elist = tc_hm->GetEntryList();
+      if (elist != nullptr) {
+        // iterate over all events in event list
+        std::size_t list_entries = elist->GetN();
+        int treenum = 0;
+        for (std::size_t l_e=0; l_e < list_entries; l_e++) {
+          auto treeEntry = elist->GetEntryAndTree(l_e,treenum);
+          auto chainEntry = treeEntry+tc_hm->GetTreeOffset()[treenum];
+          hem_reader.SetEntry(chainEntry);
+          for (const auto & hem : *hems) {
+            IntVec cat;
+            for (const auto & funcI : funcIVec_) cat.emplace_back(funcI(hem));
+            if (hem_m_.count(cat) < 1) hem_m_[cat] = {};
+            hem_m_.at(cat).emplace_back(hem);
+          }
+        }
+      } else {  
+        // read whole tree and push hemispheres to map categories  
+        while (hem_reader.Next()) {
+          for (const auto & hem : *hems) {
+            IntVec cat;
+            for (const auto & funcI : funcIVec_) cat.emplace_back(funcI(hem));
+            if (hem_m_.count(cat) < 1) hem_m_[cat] = {};
+            hem_m_.at(cat).emplace_back(hem);
+          }
+        }
+      }
+
+      std::size_t n_points(0);
+      std::vector<double> sum(funcDVec_.size(), 0.0);
+      std::vector<double> sumsq(funcDVec_.size(), 0.0);
+      for (const auto &kv : hem_m_) {
+        auto it_bool = hem_lib_.emplace(kv.first, HemisphereLibrary{kv.second,funcDVec_});
+        auto it = it_bool.first; // get iterator to inserted element
+				if (scaling_ == Scaling::subset) { 
+					it->second.scale_vars_by_subset_stds();
+				} else if (scaling_ == Scaling::set) {
+					n_points += it->second.get_n_points();
+					auto & sum_subset = it->second.get_sum();
+					auto & sumsq_subset = it->second.get_sumsq();
+					for (std::size_t i=0; i < funcDVec_.size(); i++) {
+						sum.at(i) += sum_subset.at(i);
+						sumsq.at(i) += sumsq_subset.at(i);
+					}
+				}
+      }
+
+
+			// scale by global variances if required 
+			if (scaling_ == Scaling::set) {
+        for (std::size_t i=0; i < var_stds_.size(); i++) {
+					double mu = sum.at(i)/n_points;
+					double x2 = sumsq.at(i)/n_points;
+          double var = x2-mu*mu;
+          for (std::size_t p = 0; p < n_points; p++) {
+						var_stds_.at(i) = std::sqrt(var); // fill std vector
+					}
+				}
+				for (auto & kv : hem_lib_) kv.second.scale_vars_by_stds(var_stds_);
+      }
+
+			// build kd-trees indexes
+      for (const auto & kv : hem_lib_)  {
+        auto it_bool = index_m_.emplace(kv.first,
+                       	std::unique_ptr<my_kd_tree_t>(
+											 		new my_kd_tree_t(int(funcDVec_.size()),
+                          kv.second,
+                          nanoflann::KDTreeSingleIndexAdaptorParams(10))));
+        auto it = it_bool.first; // get iterator to inserted element
+        it->second->buildIndex();
+			}
+
+    }
+
+    virtual ~HemisphereMixerOperator() {}
+
+    virtual bool process( EventClass & ev ) {
+
+      ev.best_match_hems_.clear(); // clear matched hemispheres
+      // for each original hemisphere
+      for (std::size_t h_i=0; h_i<ev.hems_.size(); h_i++) {
+
+        const auto & h = ev.hems_.at(h_i); // original event hemisphere
+        ev.best_match_hems_.emplace_back(); // emplace empty vector<alp::Hemisphere>
+        auto & b_hs = ev.best_match_hems_.back(); // reference to vector
+
+        // get integer category
+        std::vector<int> h_cat;  
+        for (const auto & funcI : funcIVec_) h_cat.emplace_back(funcI(h));
+        if (index_m_.count(h_cat) < 1) { 
+          std::cout << "No index for category: " << h_cat << std::endl;
+          return false; // remove event
+        }
+        // get matching variables vector
+        std::vector<double> h_vars;  
+        for (const auto & funcD : funcDVec_) h_vars.emplace_back(funcD(h));
+        // rescale if required
+			  if (scaling_ == Scaling::set) {
+          for (std::size_t v=0;v<h_vars.size();v++) 
+            h_vars.at(v) /= var_stds_.at(v);
+        } else if (scaling_ == Scaling::subset) {
+          for (std::size_t v=0;v<h_vars.size();v++) 
+            h_vars.at(v) /= hem_lib_.at(h_cat).var_stds_.at(v);
+        }
+
+        std::vector<std::size_t> index_nns(knn_);
+        std::vector<double> dist_nns(knn_);
+        // query kdtree
+        index_m_.at(h_cat)->knnSearch(&h_vars[0], knn_, &index_nns[0], &dist_nns[0]);
+        // vector of hemispheres corresponding to category 
+        const auto & hem_v = hem_m_.at(h_cat); 
+        for (std::size_t h_f = 0; h_f < knn_; h_f++) { 
+          b_hs.emplace_back(hem_v.at(index_nns.at(h_f)));
+          auto & sel_hem_jets = b_hs.back().jets_;
+          for (auto & j : sel_hem_jets) { 
+            if (h.d_phi_inv_)  j.p4_.SetPhi(-j.p4_.Phi()); 
+            auto n_phi = ROOT::Math::VectorUtil::Phi_mpi_pi(j.p4_.Phi() + h.p_phi_);
+            j.p4_.SetPhi(n_phi);
+            if (h.sumPz_inv_)  j.p4_.SetEta(-j.p4_.Eta()); 
+          }
+        }   
+      }
+
+      return true;
+    }
+
+    virtual bool output( TFile * tfile) {
+
+      return true;
+
+    }
+
+};
+

--- a/interface/HemisphereProducerOperator.h
+++ b/interface/HemisphereProducerOperator.h
@@ -1,0 +1,58 @@
+
+#pragma once
+
+#include <algorithm>
+#include <math.h>
+
+#include "Math/GenVector/VectorUtil.h"
+
+#include "BaseOperator.h"
+#include "Hemisphere.h"
+
+template <class EventClass> class HemisphereProducerOperator : public BaseOperator<EventClass> {
+
+  public:
+
+    HemisphereProducerOperator() {}
+    virtual ~HemisphereProducerOperator() {}
+
+    virtual bool process( EventClass & ev ) {
+
+      // get thrust phi
+      const auto & t_phi = ev.thrust_phi_;
+      auto p_phi = t_phi-M_PI/2.;
+     
+      // clear old vector and add two hemispheres
+      auto & hems = ev.hems_;
+      hems.clear();
+      hems.emplace_back(p_phi, false);
+      hems.emplace_back(p_phi, true);
+
+      // loop over all jets and push to hemispheres
+      for (std::size_t i = 0; i < ev.jets_.size(); i++ ) {     
+        const auto & jet = ev.jets_.at(i);
+        auto d_phi = ROOT::Math::VectorUtil::Phi_mpi_pi(jet.p4_.Phi() - p_phi);
+        // fill and rotate (swap phi if negative)
+        if (d_phi < 0) {  
+          hems.at(1).jets_.emplace_back(jet);   
+          hems.at(1).jets_.back().p4_.SetPhi(-d_phi);
+        } else {
+          hems.at(0).jets_.emplace_back(jet);   
+          hems.at(0).jets_.back().p4_.SetPhi(d_phi);
+        }
+      }
+      
+      // invert eta if sumPz < 0 (symmetry)
+      for (auto & hem : hems) {
+        if (hem.getSumPz() < 0) {
+          hem.sumPz_inv_ = true; // so can be reverted 
+          for (auto & j : hem.jets_) {
+            j.p4_.SetEta(-j.p4_.Eta());
+          }
+        }
+      }
+
+      return true;
+    }
+
+};

--- a/interface/HemisphereWriterOperator.h
+++ b/interface/HemisphereWriterOperator.h
@@ -1,0 +1,62 @@
+
+#pragma once
+
+#include <algorithm>
+#include <math.h>
+
+#include "Math/GenVector/VectorUtil.h"
+
+#include "BaseOperator.h"
+#include "Hemisphere.h"
+
+template <class EventClass> class HemisphereWriterOperator : public BaseOperator<EventClass> {
+
+  public:
+ 
+    bool root_;
+    std::string dir_;
+    // pointer to event hemispheres
+    std::vector<Hemisphere> * hems;
+
+    TTree hem_tree_{"hem_tree","Hemisphere tree"};
+
+     HemisphereWriterOperator(bool root = false, std::string dir = "") :
+      root_(root),
+      dir_(dir) {}
+    virtual ~HemisphereWriterOperator() {}
+
+    virtual void init(TDirectory * tdir) {
+      if (root_) {
+        tdir = tdir->GetFile();
+        auto ndir = tdir->mkdir(dir_.c_str());
+        if (ndir == 0) {
+          tdir = tdir->GetDirectory(dir_.c_str());
+        } else {
+          tdir = ndir;
+        }
+      }
+
+      hem_tree_.Branch("hems","std::vector<Hemisphere>",
+                        &hems, 64000, 1);
+      hem_tree_.SetDirectory(tdir);
+      hem_tree_.AutoSave();
+
+   }
+
+
+    virtual bool process( EventClass & ev ) {
+
+
+      hems = &ev.hems_;
+      hem_tree_.Fill();
+
+      return true;
+    }
+
+    virtual bool output( TFile * tfile) {
+
+      return true;
+
+    }
+
+};

--- a/interface/IsoMuFilterOperator.h
+++ b/interface/IsoMuFilterOperator.h
@@ -23,15 +23,8 @@ template <class EventClass> class IsoMuFilterOperator : public BaseOperator<Even
     virtual bool process( EventClass & ev ) {
 
       std::size_t nIsoMu = 0;
-      //sanity check (due to lack of muon object)
-      if(ev.muons_pt_.size() != ev.muons_pfiso03_.size()) {
-        std::cout << "WARNING: different size between muons_pt and muons_pfiso03" << std::endl;
-        return false;
-      }    
-      else {
-        for(std::size_t i=0; i< ev.muons_pt_.size(); ++i){
-          if ((ev.muons_pfiso03_[i] >= iso03_min_ ) && (ev.muons_pt_[i] <= pt_max_ )) nIsoMu++ ;
-        }
+      for(std::size_t i=0; i< ev.muons_.size(); ++i){
+          if ((ev.muons_.at(i).iso03() >= iso03_min_ ) && (ev.muons_.at(i).pt() <= pt_max_ )) nIsoMu++ ;
       }
 
       //pass selection if at least min_number_ muons in region

--- a/interface/MetFilterOperator.h
+++ b/interface/MetFilterOperator.h
@@ -18,7 +18,7 @@ template <class EventClass> class MetFilterOperator : public BaseOperator<EventC
 
     virtual bool process( EventClass & ev ) {
 
-      return (ev.met_pt_ < pt_max_ );
+      return (ev.met_.pt() < pt_max_ );
 
     }
 

--- a/interface/MixedEventWriterOperator.h
+++ b/interface/MixedEventWriterOperator.h
@@ -1,0 +1,109 @@
+
+#pragma once
+
+#include <algorithm>
+#include <math.h>
+
+#include "BaseOperator.h"
+#include "BTagFilterOperator.h"
+#include "JetPairingOperator.h"
+
+#include "Event.h"
+
+
+template <class EventClass> class MixedEventWriterOperator : public BaseOperator<EventClass> {
+
+  public:
+ 
+    // variables to save in branches
+    std::vector<alp::Jet> mix_jets_;
+    // a pointer to avoid undeclared label
+    std::vector<alp::Jet> * mix_jets_ptr_;
+
+    // hemisphere combinations to save
+    std::size_t n_h_mix_;
+    std::size_t n_h_skip_;
+
+    // to order jets after mixing
+    std::string disc_ = "pfCombinedInclusiveSecondaryVertexV2BJetTags";
+    std::size_t n_fix_jets_ = 4;
+
+    bool root_;
+    std::string dir_;
+
+
+    TTree tree_{"mix_tree","Tree wth mixed events"};
+
+     MixedEventWriterOperator(std::size_t n_h_mix = 1, std::size_t n_h_skip = 1,
+                bool root = false, std::string dir = "") :
+      mix_jets_ptr_(&mix_jets_),  
+      n_h_mix_(n_h_mix),
+      n_h_skip_(n_h_skip), 
+      root_(root),
+      dir_(dir) {}
+
+    virtual ~MixedEventWriterOperator() {}
+
+    virtual void init(TDirectory * tdir) {
+      if (root_) {
+        tdir = tdir->GetFile();
+        auto ndir = tdir->mkdir(dir_.c_str());
+        if (ndir == 0) {
+          tdir = tdir->GetDirectory(dir_.c_str());
+        } else {
+          tdir = ndir;
+        }
+      }
+
+      tree_.Branch("pfjets","std::vector<alp::Jet>",
+                   &mix_jets_ptr_, 64000, 1);
+
+
+      tree_.SetDirectory(tdir);
+      tree_.AutoSave();
+
+   }
+
+
+    virtual bool process( EventClass & ev ) {
+
+
+      const auto & bm_hems = ev.best_match_hems_;
+
+      // for each hemisphere i
+      for (std::size_t h_i=n_h_skip_; h_i<(n_h_skip_+n_h_mix_); h_i++) {
+        // for each hemisphere j
+        for (std::size_t h_j=n_h_skip_; h_j<(n_h_skip_+n_h_mix_); h_j++) {
+
+          // clear jet collection
+          mix_jets_.clear();
+
+          // references for easy access
+          const auto jets_i = bm_hems.at(0).at(h_i).jets_;
+          const auto jets_j = bm_hems.at(1).at(h_j).jets_;
+          mix_jets_.insert(mix_jets_.end(), jets_i.begin(), jets_i.end());
+          mix_jets_.insert(mix_jets_.end(), jets_j.begin(), jets_j.end());
+
+
+          // order by b-tagging disc
+          order_jets_by_disc(mix_jets_, disc_);
+          // pair with min mass
+          dijet_pairing_simple(mix_jets_, n_fix_jets_);        
+
+          // fill tree with combination
+          tree_.Fill();
+        }
+      }
+
+
+
+      return true;
+    }
+
+    virtual bool output( TFile * tfile) {
+
+      return true;
+
+    }
+
+};

--- a/interface/ThrustFinderOperator.h
+++ b/interface/ThrustFinderOperator.h
@@ -1,0 +1,85 @@
+
+#pragma once
+
+#define _USE_MATH_DEFINES
+
+#include <algorithm>
+
+#include "Math/GenVector/VectorUtil.h"
+#include "Math/Functor.h"
+#include "Math/GSLMinimizer1D.h"
+
+#include "BaseOperator.h"
+
+// operator that finds the tranverse thrust axis
+// of the jet of an event
+template <class EventClass> class ThrustFinderOperator : public BaseOperator<EventClass> {
+
+  public:
+
+    std::size_t n_steps_phi_scan_;
+    std::size_t fancyMinimizer_;
+
+    ThrustFinderOperator(std::size_t n_steps_phi_scan = 361,
+                     bool fancyMinimizer = false) : 
+      n_steps_phi_scan_(n_steps_phi_scan),
+      fancyMinimizer_(fancyMinimizer) {}
+    virtual ~ThrustFinderOperator() {}
+
+    virtual bool process( EventClass & ev ) {
+
+      const auto & reco_jets = ev.jets_;
+
+      // lambda to compute negative thrust for a given phi
+      auto neg_thrust_f = [&reco_jets](double t_phi) {
+        double neg_thrust = 0;
+        for (auto & j : reco_jets ) {
+          // deltaPhi wanted in [-PI,PI)
+          neg_thrust -= j.p4_.Pt()*std::abs(
+                        std::cos(ROOT::Math::VectorUtil::Phi_mpi_pi(j.p4_.Phi() - t_phi))
+                        );
+        }
+        return neg_thrust;
+      };
+
+
+      // first need to get an initial value for phi with a simple scan
+      double best_t_phi = 0;
+      double min_neg_thrust = 0; // will be negative
+      double phi_step = M_PI/(n_steps_phi_scan_-1);
+      for (std::size_t i=0; i < n_steps_phi_scan_; i++ ) {
+        double phi = i*phi_step;
+        double neg_thrust = neg_thrust_f(phi);    
+        if (neg_thrust < min_neg_thrust) {
+          best_t_phi = phi;
+          min_neg_thrust = neg_thrust;
+        } 
+      }
+
+      if (fancyMinimizer_) {
+
+        ROOT::Math::Functor1D neg_thrust_fc(neg_thrust_f); 
+
+        ROOT::Math::GSLMinimizer1D minzr;
+        // minization only around scan min
+        minzr.SetFunction(neg_thrust_fc, best_t_phi,
+                          best_t_phi - phi_step, best_t_phi + phi_step);
+        // max number of f calls, abs tol or rel_tol
+        minzr.Minimize(500,1e-5*M_PI, 0.);
+      }
+
+
+      // only get phi in [0,PI] (two minima in [-PI,PI])
+      if (best_t_phi < 0.) {
+        best_t_phi += M_PI;
+      } else if (best_t_phi > M_PI) {
+        best_t_phi -= M_PI;
+      }
+
+      ev.thrust_phi_ = best_t_phi;
+
+      return true;
+    }
+
+};
+

--- a/interface/TriggerOperator.h
+++ b/interface/TriggerOperator.h
@@ -14,11 +14,7 @@ template <class EventClass> class TriggerOperator : public BaseOperator<EventCla
 
     virtual bool process( EventClass & ev ) {
       for (const auto & or_path : or_paths_) {
-        for (std::size_t i=0; i<ev.hlt_bits_reader_.size(); i++) {
-          if (ev.hlt_bits_.at(i).first==or_path) {
-            if (ev.hlt_bits_.at(i).second) return true;
-          }
-        }
+        if (ev.eventInfo_.getFilter(or_path)) return true;
       }
       return false;
     }

--- a/interface/nanoflann.hpp
+++ b/interface/nanoflann.hpp
@@ -1,0 +1,1395 @@
+/***********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.
+ * Copyright 2008-2009  David G. Lowe (lowe@cs.ubc.ca). All rights reserved.
+ * Copyright 2011-2016  Jose Luis Blanco (joseluisblancoc@gmail.com).
+ *   All rights reserved.
+ *
+ * THE BSD LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *************************************************************************/
+
+/** \mainpage nanoflann C++ API documentation 
+  *  nanoflann is a C++ header-only library for building KD-Trees, mostly 
+  *  optimized for 2D or 3D point clouds. 
+  *  
+  *  nanoflann does not require compiling or installing, just an 
+  *  #include <nanoflann.hpp> in your code.  
+  *  
+  *  See: 
+  *   - <a href="modules.html" >C++ API organized by modules</a>
+  *   - <a href="https://github.com/jlblancoc/nanoflann" >Online README</a>
+  *   - <a href="http://jlblancoc.github.io/nanoflann/" >Doxygen documentation</a>
+  */
+
+#ifndef  NANOFLANN_HPP_
+#define  NANOFLANN_HPP_
+
+#include <vector>
+#include <cassert>
+#include <algorithm>
+#include <stdexcept>
+#include <cstdio>  // for fwrite()
+#include <cmath>   // for abs()
+#include <cstdlib> // for abs()
+#include <limits>
+
+// Avoid conflicting declaration of min/max macros in windows headers
+#if !defined(NOMINMAX) && (defined(_WIN32) || defined(_WIN32_)  || defined(WIN32) || defined(_WIN64))
+# define NOMINMAX
+# ifdef max
+#  undef   max
+#  undef   min
+# endif
+#endif
+
+namespace nanoflann
+{
+/** @addtogroup nanoflann_grp nanoflann C++ library for ANN
+  *  @{ */
+
+  	/** Library version: 0xMmP (M=Major,m=minor,P=patch) */
+	#define NANOFLANN_VERSION 0x121
+
+	/** @addtogroup result_sets_grp Result set classes
+	  *  @{ */
+	template <typename DistanceType, typename IndexType = size_t, typename CountType = size_t>
+	class KNNResultSet
+	{
+		IndexType * indices;
+		DistanceType* dists;
+		CountType capacity;
+		CountType count;
+
+	public:
+		inline KNNResultSet(CountType capacity_) : indices(0), dists(0), capacity(capacity_), count(0)
+		{
+		}
+
+		inline void init(IndexType* indices_, DistanceType* dists_)
+		{
+			indices = indices_;
+			dists = dists_;
+			count = 0;
+            if (capacity)
+                dists[capacity-1] = (std::numeric_limits<DistanceType>::max)();
+		}
+
+		inline CountType size() const
+		{
+			return count;
+		}
+
+		inline bool full() const
+		{
+			return count == capacity;
+		}
+
+
+		inline void addPoint(DistanceType dist, IndexType index)
+		{
+			CountType i;
+			for (i=count; i>0; --i) {
+#ifdef NANOFLANN_FIRST_MATCH   // If defined and two points have the same distance, the one with the lowest-index will be returned first.
+				if ( (dists[i-1]>dist) || ((dist==dists[i-1])&&(indices[i-1]>index)) ) {
+#else
+				if (dists[i-1]>dist) {
+#endif
+					if (i<capacity) {
+						dists[i] = dists[i-1];
+						indices[i] = indices[i-1];
+					}
+				}
+				else break;
+			}
+			if (i<capacity) {
+				dists[i] = dist;
+				indices[i] = index;
+			}
+			if (count<capacity) count++;
+		}
+
+		inline DistanceType worstDist() const
+		{
+			return dists[capacity-1];
+		}
+	};
+
+
+	/**
+	 * A result-set class used when performing a radius based search.
+	 */
+	template <typename DistanceType, typename IndexType = size_t>
+	class RadiusResultSet
+	{
+	public:
+		const DistanceType radius;
+
+		std::vector<std::pair<IndexType,DistanceType> >& m_indices_dists;
+
+		inline RadiusResultSet(DistanceType radius_, std::vector<std::pair<IndexType,DistanceType> >& indices_dists) : radius(radius_), m_indices_dists(indices_dists)
+		{
+			init();
+		}
+
+		inline ~RadiusResultSet() { }
+
+		inline void init() { clear(); }
+		inline void clear() { m_indices_dists.clear(); }
+
+		inline size_t size() const { return m_indices_dists.size(); }
+
+		inline bool full() const { return true; }
+
+		inline void addPoint(DistanceType dist, IndexType index)
+		{
+			if (dist<radius)
+				m_indices_dists.push_back(std::make_pair(index,dist));
+		}
+
+		inline DistanceType worstDist() const { return radius; }
+
+		/** Clears the result set and adjusts the search radius. */
+		inline void set_radius_and_clear( const DistanceType r )
+		{
+			radius = r;
+			clear();
+		}
+
+		/**
+		 * Find the worst result (furtherest neighbor) without copying or sorting
+		 * Pre-conditions: size() > 0
+		 */
+		std::pair<IndexType,DistanceType> worst_item() const
+		{
+		   if (m_indices_dists.empty()) throw std::runtime_error("Cannot invoke RadiusResultSet::worst_item() on an empty list of results.");
+		   typedef typename std::vector<std::pair<IndexType,DistanceType> >::const_iterator DistIt;
+		   DistIt it = std::max_element(m_indices_dists.begin(), m_indices_dists.end());
+		   return *it;
+		}
+	};
+
+	/** operator "<" for std::sort() */
+	struct IndexDist_Sorter
+	{
+		/** PairType will be typically: std::pair<IndexType,DistanceType> */
+		template <typename PairType>
+		inline bool operator()(const PairType &p1, const PairType &p2) const {
+			return p1.second < p2.second;
+		}
+	};
+
+	/** @} */
+
+
+	/** @addtogroup loadsave_grp Load/save auxiliary functions
+	  * @{ */
+	template<typename T>
+	void save_value(FILE* stream, const T& value, size_t count = 1)
+	{
+		fwrite(&value, sizeof(value),count, stream);
+	}
+
+	template<typename T>
+	void save_value(FILE* stream, const std::vector<T>& value)
+	{
+		size_t size = value.size();
+		fwrite(&size, sizeof(size_t), 1, stream);
+		fwrite(&value[0], sizeof(T), size, stream);
+	}
+
+	template<typename T>
+	void load_value(FILE* stream, T& value, size_t count = 1)
+	{
+		size_t read_cnt = fread(&value, sizeof(value), count, stream);
+		if (read_cnt != count) {
+			throw std::runtime_error("Cannot read from file");
+		}
+	}
+
+
+	template<typename T>
+	void load_value(FILE* stream, std::vector<T>& value)
+	{
+		size_t size;
+		size_t read_cnt = fread(&size, sizeof(size_t), 1, stream);
+		if (read_cnt!=1) {
+			throw std::runtime_error("Cannot read from file");
+		}
+		value.resize(size);
+		read_cnt = fread(&value[0], sizeof(T), size, stream);
+		if (read_cnt!=size) {
+			throw std::runtime_error("Cannot read from file");
+		}
+	}
+	/** @} */
+
+
+	/** @addtogroup metric_grp Metric (distance) classes
+	  * @{ */
+
+	/** Manhattan distance functor (generic version, optimized for high-dimensionality data sets).
+	  *  Corresponding distance traits: nanoflann::metric_L1
+	  * \tparam T Type of the elements (e.g. double, float, uint8_t)
+	  * \tparam _DistanceType Type of distance variables (must be signed) (e.g. float, double, int64_t)
+	  */
+	template<class T, class DataSource, typename _DistanceType = T>
+	struct L1_Adaptor
+	{
+		typedef T ElementType;
+		typedef _DistanceType DistanceType;
+
+		const DataSource &data_source;
+
+		L1_Adaptor(const DataSource &_data_source) : data_source(_data_source) { }
+
+		inline DistanceType operator()(const T* a, const size_t b_idx, size_t size, DistanceType worst_dist = -1) const
+		{
+			DistanceType result = DistanceType();
+			const T* last = a + size;
+			const T* lastgroup = last - 3;
+			size_t d = 0;
+
+			/* Process 4 items with each loop for efficiency. */
+			while (a < lastgroup) {
+				const DistanceType diff0 = std::abs(a[0] - data_source.kdtree_get_pt(b_idx,d++));
+				const DistanceType diff1 = std::abs(a[1] - data_source.kdtree_get_pt(b_idx,d++));
+				const DistanceType diff2 = std::abs(a[2] - data_source.kdtree_get_pt(b_idx,d++));
+				const DistanceType diff3 = std::abs(a[3] - data_source.kdtree_get_pt(b_idx,d++));
+				result += diff0 + diff1 + diff2 + diff3;
+				a += 4;
+				if ((worst_dist>0)&&(result>worst_dist)) {
+					return result;
+				}
+			}
+			/* Process last 0-3 components.  Not needed for standard vector lengths. */
+			while (a < last) {
+				result += std::abs( *a++ - data_source.kdtree_get_pt(b_idx,d++) );
+			}
+			return result;
+		}
+
+		template <typename U, typename V>
+		inline DistanceType accum_dist(const U a, const V b, int ) const
+		{
+			return std::abs(a-b);
+		}
+	};
+
+	/** Squared Euclidean distance functor (generic version, optimized for high-dimensionality data sets).
+	  *  Corresponding distance traits: nanoflann::metric_L2
+	  * \tparam T Type of the elements (e.g. double, float, uint8_t)
+	  * \tparam _DistanceType Type of distance variables (must be signed) (e.g. float, double, int64_t)
+	  */
+	template<class T, class DataSource, typename _DistanceType = T>
+	struct L2_Adaptor
+	{
+		typedef T ElementType;
+		typedef _DistanceType DistanceType;
+
+		const DataSource &data_source;
+
+		L2_Adaptor(const DataSource &_data_source) : data_source(_data_source) { }
+
+		inline DistanceType operator()(const T* a, const size_t b_idx, size_t size, DistanceType worst_dist = -1) const
+		{
+			DistanceType result = DistanceType();
+			const T* last = a + size;
+			const T* lastgroup = last - 3;
+			size_t d = 0;
+
+			/* Process 4 items with each loop for efficiency. */
+			while (a < lastgroup) {
+				const DistanceType diff0 = a[0] - data_source.kdtree_get_pt(b_idx,d++);
+				const DistanceType diff1 = a[1] - data_source.kdtree_get_pt(b_idx,d++);
+				const DistanceType diff2 = a[2] - data_source.kdtree_get_pt(b_idx,d++);
+				const DistanceType diff3 = a[3] - data_source.kdtree_get_pt(b_idx,d++);
+				result += diff0 * diff0 + diff1 * diff1 + diff2 * diff2 + diff3 * diff3;
+				a += 4;
+				if ((worst_dist>0)&&(result>worst_dist)) {
+					return result;
+				}
+			}
+			/* Process last 0-3 components.  Not needed for standard vector lengths. */
+			while (a < last) {
+				const DistanceType diff0 = *a++ - data_source.kdtree_get_pt(b_idx,d++);
+				result += diff0 * diff0;
+			}
+			return result;
+		}
+
+		template <typename U, typename V>
+		inline DistanceType accum_dist(const U a, const V b, int ) const
+		{
+			return (a-b)*(a-b);
+		}
+	};
+
+	/** Squared Euclidean (L2) distance functor (suitable for low-dimensionality datasets, like 2D or 3D point clouds)
+	  *  Corresponding distance traits: nanoflann::metric_L2_Simple
+	  * \tparam T Type of the elements (e.g. double, float, uint8_t)
+	  * \tparam _DistanceType Type of distance variables (must be signed) (e.g. float, double, int64_t)
+	  */
+	template<class T, class DataSource, typename _DistanceType = T>
+	struct L2_Simple_Adaptor
+	{
+		typedef T ElementType;
+		typedef _DistanceType DistanceType;
+
+		const DataSource &data_source;
+
+		L2_Simple_Adaptor(const DataSource &_data_source) : data_source(_data_source) { }
+
+		inline DistanceType operator()(const T* a, const size_t b_idx, size_t size) const {
+			return data_source.kdtree_distance(a,b_idx,size);
+		}
+
+		template <typename U, typename V>
+		inline DistanceType accum_dist(const U a, const V b, int ) const
+		{
+			return (a-b)*(a-b);
+		}
+	};
+
+	/** Metaprogramming helper traits class for the L1 (Manhattan) metric */
+	struct metric_L1 {
+		template<class T, class DataSource>
+		struct traits {
+			typedef L1_Adaptor<T,DataSource> distance_t;
+		};
+	};
+	/** Metaprogramming helper traits class for the L2 (Euclidean) metric */
+	struct metric_L2 {
+		template<class T, class DataSource>
+		struct traits {
+			typedef L2_Adaptor<T,DataSource> distance_t;
+		};
+	};
+	/** Metaprogramming helper traits class for the L2_simple (Euclidean) metric */
+	struct metric_L2_Simple {
+		template<class T, class DataSource>
+		struct traits {
+			typedef L2_Simple_Adaptor<T,DataSource> distance_t;
+		};
+	};
+
+	/** @} */
+
+	/** @addtogroup param_grp Parameter structs
+	  * @{ */
+
+	/**  Parameters (see README.md) */
+	struct KDTreeSingleIndexAdaptorParams
+	{
+		KDTreeSingleIndexAdaptorParams(size_t _leaf_max_size = 10) :
+			leaf_max_size(_leaf_max_size)
+		{}
+
+		size_t leaf_max_size;
+	};
+
+	/** Search options for KDTreeSingleIndexAdaptor::findNeighbors() */
+	struct SearchParams
+	{
+		/** Note: The first argument (checks_IGNORED_) is ignored, but kept for compatibility with the FLANN interface */
+		SearchParams(int checks_IGNORED_ = 32, float eps_ = 0, bool sorted_ = true ) :
+			checks(checks_IGNORED_), eps(eps_), sorted(sorted_) {}
+
+		int   checks;  //!< Ignored parameter (Kept for compatibility with the FLANN interface).
+		float eps;  //!< search for eps-approximate neighbours (default: 0)
+		bool sorted; //!< only for radius search, require neighbours sorted by distance (default: true)
+	};
+	/** @} */
+
+
+	/** @addtogroup memalloc_grp Memory allocation
+	  * @{ */
+
+	/**
+	 * Allocates (using C's malloc) a generic type T.
+	 *
+	 * Params:
+	 *     count = number of instances to allocate.
+	 * Returns: pointer (of type T*) to memory buffer
+	 */
+	template <typename T>
+	inline T* allocate(size_t count = 1)
+	{
+		T* mem = static_cast<T*>( ::malloc(sizeof(T)*count));
+		return mem;
+	}
+
+
+	/**
+	 * Pooled storage allocator
+	 *
+	 * The following routines allow for the efficient allocation of storage in
+	 * small chunks from a specified pool.  Rather than allowing each structure
+	 * to be freed individually, an entire pool of storage is freed at once.
+	 * This method has two advantages over just using malloc() and free().  First,
+	 * it is far more efficient for allocating small objects, as there is
+	 * no overhead for remembering all the information needed to free each
+	 * object or consolidating fragmented memory.  Second, the decision about
+	 * how long to keep an object is made at the time of allocation, and there
+	 * is no need to track down all the objects to free them.
+	 *
+	 */
+
+	const size_t     WORDSIZE=16;
+	const size_t     BLOCKSIZE_NF=8192;
+
+	class PooledAllocator
+	{
+		/* We maintain memory alignment to word boundaries by requiring that all
+		    allocations be in multiples of the machine wordsize.  */
+		/* Size of machine word in bytes.  Must be power of 2. */
+		/* Minimum number of bytes requested at a time from	the system.  Must be multiple of WORDSIZE. */
+
+
+		size_t  remaining;  /* Number of bytes left in current block of storage. */
+		void*   base;     /* Pointer to base of current block of storage. */
+		void*   loc;      /* Current location in block to next allocate memory. */
+
+		void internal_init()
+		{
+			remaining = 0;
+			base = NULL;
+			usedMemory = 0;
+			wastedMemory = 0;
+		}
+
+	public:
+		size_t  usedMemory;
+		size_t  wastedMemory;
+
+		/**
+		    Default constructor. Initializes a new pool.
+		 */
+		PooledAllocator() {
+			internal_init();
+		}
+
+		/**
+		 * Destructor. Frees all the memory allocated in this pool.
+		 */
+		~PooledAllocator() {
+			free_all();
+		}
+
+		/** Frees all allocated memory chunks */
+		void free_all()
+		{
+			while (base != NULL) {
+				void *prev = *(static_cast<void**>( base)); /* Get pointer to prev block. */
+				::free(base);
+				base = prev;
+			}
+			internal_init();
+		}
+
+		/**
+		 * Returns a pointer to a piece of new memory of the given size in bytes
+		 * allocated from the pool.
+		 */
+		void* malloc(const size_t req_size)
+		{
+			/* Round size up to a multiple of wordsize.  The following expression
+			    only works for WORDSIZE that is a power of 2, by masking last bits of
+			    incremented size to zero.
+			 */
+			const size_t size = (req_size + (WORDSIZE - 1)) & ~(WORDSIZE - 1);
+
+			/* Check whether a new block must be allocated.  Note that the first word
+			    of a block is reserved for a pointer to the previous block.
+			 */
+			if (size > remaining) {
+
+				wastedMemory += remaining;
+
+				/* Allocate new storage. */
+				const size_t blocksize = (size + sizeof(void*) + (WORDSIZE-1) > BLOCKSIZE_NF) ?
+							size + sizeof(void*) + (WORDSIZE-1) : BLOCKSIZE_NF;
+
+				// use the standard C malloc to allocate memory
+				void* m = ::malloc(blocksize);
+				if (!m) {
+					fprintf(stderr,"Failed to allocate memory.\n");
+					return NULL;
+				}
+
+				/* Fill first word of new block with pointer to previous block. */
+				static_cast<void**>(m)[0] = base;
+				base = m;
+
+				size_t shift = 0;
+				//int size_t = (WORDSIZE - ( (((size_t)m) + sizeof(void*)) & (WORDSIZE-1))) & (WORDSIZE-1);
+
+				remaining = blocksize - sizeof(void*) - shift;
+				loc = (static_cast<char*>(m) + sizeof(void*) + shift);
+			}
+			void* rloc = loc;
+			loc = static_cast<char*>(loc) + size;
+			remaining -= size;
+
+			usedMemory += size;
+
+			return rloc;
+		}
+
+		/**
+		 * Allocates (using this pool) a generic type T.
+		 *
+		 * Params:
+		 *     count = number of instances to allocate.
+		 * Returns: pointer (of type T*) to memory buffer
+		 */
+		template <typename T>
+		T* allocate(const size_t count = 1)
+		{
+			T* mem = static_cast<T*>(this->malloc(sizeof(T)*count));
+			return mem;
+		}
+
+	};
+	/** @} */
+
+	/** @addtogroup nanoflann_metaprog_grp Auxiliary metaprogramming stuff
+	  * @{ */
+
+	// ----------------  CArray -------------------------
+	/** A STL container (as wrapper) for arrays of constant size defined at compile time (class imported from the MRPT project)
+	 * This code is an adapted version from Boost, modifed for its integration
+	 *	within MRPT (JLBC, Dec/2009) (Renamed array -> CArray to avoid possible potential conflicts).
+	 * See
+	 *      http://www.josuttis.com/cppcode
+	 * for details and the latest version.
+	 * See
+	 *      http://www.boost.org/libs/array for Documentation.
+	 * for documentation.
+	 *
+	 * (C) Copyright Nicolai M. Josuttis 2001.
+	 * Permission to copy, use, modify, sell and distribute this software
+	 * is granted provided this copyright notice appears in all copies.
+	 * This software is provided "as is" without express or implied
+	 * warranty, and with no claim as to its suitability for any purpose.
+	 *
+	 * 29 Jan 2004 - minor fixes (Nico Josuttis)
+	 * 04 Dec 2003 - update to synch with library TR1 (Alisdair Meredith)
+	 * 23 Aug 2002 - fix for Non-MSVC compilers combined with MSVC libraries.
+	 * 05 Aug 2001 - minor update (Nico Josuttis)
+	 * 20 Jan 2001 - STLport fix (Beman Dawes)
+	 * 29 Sep 2000 - Initial Revision (Nico Josuttis)
+	 *
+	 * Jan 30, 2004
+	 */
+    template <typename T, std::size_t N>
+    class CArray {
+      public:
+        T elems[N];    // fixed-size array of elements of type T
+
+      public:
+        // type definitions
+        typedef T              value_type;
+        typedef T*             iterator;
+        typedef const T*       const_iterator;
+        typedef T&             reference;
+        typedef const T&       const_reference;
+        typedef std::size_t    size_type;
+        typedef std::ptrdiff_t difference_type;
+
+        // iterator support
+        inline iterator begin() { return elems; }
+        inline const_iterator begin() const { return elems; }
+        inline iterator end() { return elems+N; }
+        inline const_iterator end() const { return elems+N; }
+
+        // reverse iterator support
+#if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) && !defined(BOOST_MSVC_STD_ITERATOR) && !defined(BOOST_NO_STD_ITERATOR_TRAITS)
+        typedef std::reverse_iterator<iterator> reverse_iterator;
+        typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+#elif defined(_MSC_VER) && (_MSC_VER == 1300) && defined(BOOST_DINKUMWARE_STDLIB) && (BOOST_DINKUMWARE_STDLIB == 310)
+        // workaround for broken reverse_iterator in VC7
+        typedef std::reverse_iterator<std::_Ptrit<value_type, difference_type, iterator,
+                                      reference, iterator, reference> > reverse_iterator;
+        typedef std::reverse_iterator<std::_Ptrit<value_type, difference_type, const_iterator,
+                                      const_reference, iterator, reference> > const_reverse_iterator;
+#else
+        // workaround for broken reverse_iterator implementations
+        typedef std::reverse_iterator<iterator,T> reverse_iterator;
+        typedef std::reverse_iterator<const_iterator,T> const_reverse_iterator;
+#endif
+
+        reverse_iterator rbegin() { return reverse_iterator(end()); }
+        const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+        reverse_iterator rend() { return reverse_iterator(begin()); }
+        const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+        // operator[]
+        inline reference operator[](size_type i) { return elems[i]; }
+        inline const_reference operator[](size_type i) const { return elems[i]; }
+        // at() with range check
+        reference at(size_type i) { rangecheck(i); return elems[i]; }
+        const_reference at(size_type i) const { rangecheck(i); return elems[i]; }
+        // front() and back()
+        reference front() { return elems[0]; }
+        const_reference front() const { return elems[0]; }
+        reference back() { return elems[N-1]; }
+        const_reference back() const { return elems[N-1]; }
+        // size is constant
+        static inline size_type size() { return N; }
+        static bool empty() { return false; }
+        static size_type max_size() { return N; }
+        enum { static_size = N };
+		/** This method has no effects in this class, but raises an exception if the expected size does not match */
+		inline void resize(const size_t nElements) { if (nElements!=N) throw std::logic_error("Try to change the size of a CArray."); }
+        // swap (note: linear complexity in N, constant for given instantiation)
+        void swap (CArray<T,N>& y) { std::swap_ranges(begin(),end(),y.begin()); }
+        // direct access to data (read-only)
+        const T* data() const { return elems; }
+        // use array as C array (direct read/write access to data)
+        T* data() { return elems; }
+        // assignment with type conversion
+        template <typename T2> CArray<T,N>& operator= (const CArray<T2,N>& rhs) {
+            std::copy(rhs.begin(),rhs.end(), begin());
+            return *this;
+        }
+        // assign one value to all elements
+        inline void assign (const T& value) { for (size_t i=0;i<N;i++) elems[i]=value; }
+        // assign (compatible with std::vector's one) (by JLBC for MRPT)
+        void assign (const size_t n, const T& value) { assert(N==n); for (size_t i=0;i<N;i++) elems[i]=value; }
+      private:
+        // check range (may be private because it is static)
+        static void rangecheck (size_type i) { if (i >= size()) { throw std::out_of_range("CArray<>: index out of range"); } }
+    }; // end of CArray
+
+	/** Used to declare fixed-size arrays when DIM>0, dynamically-allocated vectors when DIM=-1.
+	  * Fixed size version for a generic DIM:
+	  */
+	template <int DIM, typename T>
+	struct array_or_vector_selector
+	{
+		typedef CArray<T,DIM> container_t;
+	};
+	/** Dynamic size version */
+	template <typename T>
+	struct array_or_vector_selector<-1,T> {
+		typedef std::vector<T> container_t;
+	};
+	/** @} */
+
+	/** @addtogroup kdtrees_grp KD-tree classes and adaptors
+	  * @{ */
+
+	/** kd-tree index
+	 *
+	 * Contains the k-d trees and other information for indexing a set of points
+	 * for nearest-neighbor matching.
+	 *
+	 *  The class "DatasetAdaptor" must provide the following interface (can be non-virtual, inlined methods):
+	 *
+	 *  \code
+	 *   // Must return the number of data poins
+	 *   inline size_t kdtree_get_point_count() const { ... }
+	 *
+	 *   // [Only if using the metric_L2_Simple type] Must return the Euclidean (L2) distance between the vector "p1[0:size-1]" and the data point with index "idx_p2" stored in the class:
+	 *   inline DistanceType kdtree_distance(const T *p1, const size_t idx_p2,size_t size) const { ... }
+	 *
+	 *   // Must return the dim'th component of the idx'th point in the class:
+	 *   inline T kdtree_get_pt(const size_t idx, int dim) const { ... }
+	 *
+	 *   // Optional bounding-box computation: return false to default to a standard bbox computation loop.
+	 *   //   Return true if the BBOX was already computed by the class and returned in "bb" so it can be avoided to redo it again.
+	 *   //   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3 for point clouds)
+	 *   template <class BBOX>
+	 *   bool kdtree_get_bbox(BBOX &bb) const
+	 *   {
+	 *      bb[0].low = ...; bb[0].high = ...;  // 0th dimension limits
+	 *      bb[1].low = ...; bb[1].high = ...;  // 1st dimension limits
+	 *      ...
+	 *      return true;
+	 *   }
+	 *
+	 *  \endcode
+	 * 
+	 * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
+	 * \tparam Distance The distance metric to use: nanoflann::metric_L1, nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
+	 * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
+	 * \tparam IndexType Will be typically size_t or int
+	 */
+	template <typename Distance, class DatasetAdaptor,int DIM = -1, typename IndexType = size_t>
+	class KDTreeSingleIndexAdaptor
+	{
+	private:
+		/** Hidden copy constructor, to disallow copying indices (Not implemented) */
+		KDTreeSingleIndexAdaptor(const KDTreeSingleIndexAdaptor<Distance,DatasetAdaptor,DIM,IndexType>&);
+	public:
+		typedef typename Distance::ElementType  ElementType;
+		typedef typename Distance::DistanceType DistanceType;
+	protected:
+
+		/**
+		 *  Array of indices to vectors in the dataset.
+		 */
+		std::vector<IndexType> vind;
+
+		size_t m_leaf_max_size;
+
+
+		/**
+		 * The dataset used by this index
+		 */
+		const DatasetAdaptor &dataset; //!< The source of our data
+
+		const KDTreeSingleIndexAdaptorParams index_params;
+
+		size_t m_size; //!< Number of current poins in the dataset
+		size_t m_size_at_index_build; //!< Number of points in the dataset when the index was built
+		int dim;  //!< Dimensionality of each data point
+
+
+		/*--------------------- Internal Data Structures --------------------------*/
+		struct Node
+		{
+			/** Union used because a node can be either a LEAF node or a non-leaf node, so both data fields are never used simultaneously */
+			union {
+				struct leaf
+                                {
+					IndexType    left, right;  //!< Indices of points in leaf node
+				} lr;
+				struct nonleaf
+                                {
+					int          divfeat; //!< Dimension used for subdivision.
+					DistanceType divlow, divhigh; //!< The values used for subdivision.
+				} sub;
+			} node_type;
+			Node* child1, * child2;  //!< Child nodes (both=NULL mean its a leaf node)
+		};
+		typedef Node* NodePtr;
+
+
+		struct Interval
+		{
+			ElementType low, high;
+		};
+
+		/** Define "BoundingBox" as a fixed-size or variable-size container depending on "DIM" */
+		typedef typename array_or_vector_selector<DIM,Interval>::container_t BoundingBox;
+
+		/** Define "distance_vector_t" as a fixed-size or variable-size container depending on "DIM" */
+		typedef typename array_or_vector_selector<DIM,DistanceType>::container_t distance_vector_t;
+
+		/** The KD-tree used to find neighbours */
+		NodePtr root_node;
+		BoundingBox root_bbox;
+
+		/**
+		 * Pooled memory allocator.
+		 *
+		 * Using a pooled memory allocator is more efficient
+		 * than allocating memory directly when there is a large
+		 * number small of memory allocations.
+		 */
+		PooledAllocator pool;
+
+	public:
+
+		Distance distance;
+
+		/**
+		 * KDTree constructor
+		 *
+		 * Refer to docs in README.md or online in https://github.com/jlblancoc/nanoflann
+		 *
+		 * The KD-Tree point dimension (the length of each point in the datase, e.g. 3 for 3D points)
+		 * is determined by means of:
+		 *  - The \a DIM template parameter if >0 (highest priority)
+		 *  - Otherwise, the \a dimensionality parameter of this constructor.
+		 *
+		 * @param inputData Dataset with the input features
+		 * @param params Basically, the maximum leaf node size
+		 */
+		KDTreeSingleIndexAdaptor(const int dimensionality, const DatasetAdaptor& inputData, const KDTreeSingleIndexAdaptorParams& params = KDTreeSingleIndexAdaptorParams() ) :
+			dataset(inputData), index_params(params), root_node(NULL), distance(inputData)
+		{
+			m_size = dataset.kdtree_get_point_count();
+			m_size_at_index_build = m_size;
+			dim = dimensionality;
+			if (DIM>0) dim=DIM;
+			m_leaf_max_size = params.leaf_max_size;
+
+			// Create a permutable array of indices to the input vectors.
+			init_vind();
+		}
+
+		/** Standard destructor */
+		~KDTreeSingleIndexAdaptor() { }
+
+		/** Frees the previously-built index. Automatically called within buildIndex(). */
+		void freeIndex()
+		{
+			pool.free_all();
+			root_node=NULL;
+			m_size_at_index_build = 0;
+		}
+
+		/**
+		 * Builds the index
+		 */
+		void buildIndex()
+		{
+			init_vind();
+			freeIndex();
+			m_size_at_index_build = m_size;
+			if(m_size == 0) return;
+			computeBoundingBox(root_bbox);
+			root_node = divideTree(0, m_size, root_bbox );   // construct the tree
+		}
+
+		/** Returns number of points in dataset  */
+		size_t size() const { return m_size; }
+
+		/** Returns the length of each point in the dataset */
+		size_t veclen() const {
+			return static_cast<size_t>(DIM>0 ? DIM : dim);
+		}
+
+		/**
+		 * Computes the inde memory usage
+		 * Returns: memory used by the index
+		 */
+		size_t usedMemory() const
+		{
+			return pool.usedMemory+pool.wastedMemory+dataset.kdtree_get_point_count()*sizeof(IndexType);  // pool memory and vind array memory
+		}
+
+		/** \name Query methods
+		  * @{ */
+
+		/**
+		 * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored inside
+		 * the result object.
+		 *
+		 * Params:
+		 *     result = the result object in which the indices of the nearest-neighbors are stored
+		 *     vec = the vector for which to search the nearest neighbors
+		 *
+		 * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         * \return  True if the requested neighbors could be found.
+		 * \sa knnSearch, radiusSearch
+		 */
+		template <typename RESULTSET>
+		bool findNeighbors(RESULTSET& result, const ElementType* vec, const SearchParams& searchParams) const
+		{
+			assert(vec);
+            if (size() == 0)
+                return false;
+			if (!root_node)
+                throw std::runtime_error("[nanoflann] findNeighbors() called before building the index.");
+			float epsError = 1+searchParams.eps;
+
+			distance_vector_t dists; // fixed or variable-sized container (depending on DIM)
+			dists.assign((DIM>0 ? DIM : dim) ,0); // Fill it with zeros.
+			DistanceType distsq = computeInitialDistances(vec, dists);
+			searchLevel(result, vec, root_node, distsq, dists, epsError);  // "count_leaf" parameter removed since was neither used nor returned to the user.
+            return result.full();
+		}
+
+		/**
+		 * Find the "num_closest" nearest neighbors to the \a query_point[0:dim-1]. Their indices are stored inside
+		 * the result object.
+		 *  \sa radiusSearch, findNeighbors
+		 * \note nChecks_IGNORED is ignored but kept for compatibility with the original FLANN interface.
+		 */
+		inline void knnSearch(const ElementType *query_point, const size_t num_closest, IndexType *out_indices, DistanceType *out_distances_sq, const int /* nChecks_IGNORED */ = 10) const
+		{
+			nanoflann::KNNResultSet<DistanceType,IndexType> resultSet(num_closest);
+			resultSet.init(out_indices, out_distances_sq);
+			this->findNeighbors(resultSet, query_point, nanoflann::SearchParams());
+		}
+
+		/**
+		 * Find all the neighbors to \a query_point[0:dim-1] within a maximum radius.
+		 *  The output is given as a vector of pairs, of which the first element is a point index and the second the corresponding distance.
+		 *  Previous contents of \a IndicesDists are cleared.
+		 *
+		 *  If searchParams.sorted==true, the output list is sorted by ascending distances.
+		 *
+		 *  For a better performance, it is advisable to do a .reserve() on the vector if you have any wild guess about the number of expected matches.
+		 *
+		 *  \sa knnSearch, findNeighbors, radiusSearchCustomCallback
+		 * \return The number of points within the given radius (i.e. indices.size() or dists.size() )
+		 */
+		size_t radiusSearch(const ElementType *query_point,const DistanceType &radius, std::vector<std::pair<IndexType,DistanceType> >& IndicesDists, const SearchParams& searchParams) const 
+		{
+			RadiusResultSet<DistanceType,IndexType> resultSet(radius,IndicesDists);
+			const size_t nFound = radiusSearchCustomCallback(query_point,resultSet,searchParams);
+			if (searchParams.sorted)
+				std::sort(IndicesDists.begin(),IndicesDists.end(), IndexDist_Sorter() );
+			return nFound;
+		}
+
+		/** 
+		 * Just like radiusSearch() but with a custom callback class for each point found in the radius of the query.
+		 * See the source of RadiusResultSet<> as a start point for your own classes.
+		 * \sa radiusSearch
+		 */
+		template <class SEARCH_CALLBACK>
+		size_t radiusSearchCustomCallback(const ElementType *query_point,SEARCH_CALLBACK &resultSet, const SearchParams& searchParams = SearchParams() ) const
+		{
+			this->findNeighbors(resultSet, query_point, searchParams);
+			return resultSet.size();
+		}
+
+		/** @} */
+
+	private:
+		/** Make sure the auxiliary list \a vind has the same size than the current dataset, and re-generate if size has changed. */
+		void init_vind()
+		{
+			// Create a permutable array of indices to the input vectors.
+			m_size = dataset.kdtree_get_point_count();
+			if (vind.size()!=m_size) vind.resize(m_size);
+			for (size_t i = 0; i < m_size; i++) vind[i] = i;
+		}
+
+		/// Helper accessor to the dataset points:
+		inline ElementType dataset_get(size_t idx, int component) const {
+			return dataset.kdtree_get_pt(idx,component);
+		}
+
+
+		void save_tree(FILE* stream, NodePtr tree)
+		{
+			save_value(stream, *tree);
+			if (tree->child1!=NULL) {
+				save_tree(stream, tree->child1);
+			}
+			if (tree->child2!=NULL) {
+				save_tree(stream, tree->child2);
+			}
+		}
+
+
+		void load_tree(FILE* stream, NodePtr& tree)
+		{
+			tree = pool.allocate<Node>();
+			load_value(stream, *tree);
+			if (tree->child1!=NULL) {
+				load_tree(stream, tree->child1);
+			}
+			if (tree->child2!=NULL) {
+				load_tree(stream, tree->child2);
+			}
+		}
+
+
+		void computeBoundingBox(BoundingBox& bbox)
+		{
+			bbox.resize((DIM>0 ? DIM : dim));
+			if (dataset.kdtree_get_bbox(bbox))
+			{
+				// Done! It was implemented in derived class
+			}
+			else
+			{
+				const size_t N = dataset.kdtree_get_point_count();
+				if (!N) throw std::runtime_error("[nanoflann] computeBoundingBox() called but no data points found.");
+				for (int i=0; i<(DIM>0 ? DIM : dim); ++i) {
+					bbox[i].low =
+					bbox[i].high = dataset_get(0,i);
+				}
+				for (size_t k=1; k<N; ++k) {
+					for (int i=0; i<(DIM>0 ? DIM : dim); ++i) {
+						if (dataset_get(k,i)<bbox[i].low) bbox[i].low = dataset_get(k,i);
+						if (dataset_get(k,i)>bbox[i].high) bbox[i].high = dataset_get(k,i);
+					}
+				}
+			}
+		}
+
+
+		/**
+		 * Create a tree node that subdivides the list of vecs from vind[first]
+		 * to vind[last].  The routine is called recursively on each sublist.
+		 *
+		 * @param left index of the first vector
+		 * @param right index of the last vector
+		 */
+		NodePtr divideTree(const IndexType left, const IndexType right, BoundingBox& bbox)
+		{
+			NodePtr node = pool.allocate<Node>(); // allocate memory
+
+			/* If too few exemplars remain, then make this a leaf node. */
+			if ( (right-left) <= static_cast<IndexType>(m_leaf_max_size) ) {
+				node->child1 = node->child2 = NULL;    /* Mark as leaf node. */
+				node->node_type.lr.left = left;
+				node->node_type.lr.right = right;
+
+				// compute bounding-box of leaf points
+				for (int i=0; i<(DIM>0 ? DIM : dim); ++i) {
+					bbox[i].low = dataset_get(vind[left],i);
+					bbox[i].high = dataset_get(vind[left],i);
+				}
+				for (IndexType k=left+1; k<right; ++k) {
+					for (int i=0; i<(DIM>0 ? DIM : dim); ++i) {
+						if (bbox[i].low>dataset_get(vind[k],i)) bbox[i].low=dataset_get(vind[k],i);
+						if (bbox[i].high<dataset_get(vind[k],i)) bbox[i].high=dataset_get(vind[k],i);
+					}
+				}
+			}
+			else {
+				IndexType idx;
+				int cutfeat;
+				DistanceType cutval;
+				middleSplit_(&vind[0]+left, right-left, idx, cutfeat, cutval, bbox);
+
+				node->node_type.sub.divfeat = cutfeat;
+
+				BoundingBox left_bbox(bbox);
+				left_bbox[cutfeat].high = cutval;
+				node->child1 = divideTree(left, left+idx, left_bbox);
+
+				BoundingBox right_bbox(bbox);
+				right_bbox[cutfeat].low = cutval;
+				node->child2 = divideTree(left+idx, right, right_bbox);
+
+				node->node_type.sub.divlow = left_bbox[cutfeat].high;
+				node->node_type.sub.divhigh = right_bbox[cutfeat].low;
+
+				for (int i=0; i<(DIM>0 ? DIM : dim); ++i) {
+					bbox[i].low = std::min(left_bbox[i].low, right_bbox[i].low);
+					bbox[i].high = std::max(left_bbox[i].high, right_bbox[i].high);
+				}
+			}
+
+			return node;
+		}
+
+
+		void computeMinMax(IndexType* ind, IndexType count, int element, ElementType& min_elem, ElementType& max_elem)
+		{
+			min_elem = dataset_get(ind[0],element);
+			max_elem = dataset_get(ind[0],element);
+			for (IndexType i=1; i<count; ++i) {
+				ElementType val = dataset_get(ind[i],element);
+				if (val<min_elem) min_elem = val;
+				if (val>max_elem) max_elem = val;
+			}
+		}
+
+		void middleSplit_(IndexType* ind, IndexType count, IndexType& index, int& cutfeat, DistanceType& cutval, const BoundingBox& bbox)
+		{
+			const DistanceType EPS=static_cast<DistanceType>(0.00001);
+			ElementType max_span = bbox[0].high-bbox[0].low;
+			for (int i=1; i<(DIM>0 ? DIM : dim); ++i) {
+				ElementType span = bbox[i].high-bbox[i].low;
+				if (span>max_span) {
+					max_span = span;
+				}
+			}
+			ElementType max_spread = -1;
+			cutfeat = 0;
+			for (int i=0; i<(DIM>0 ? DIM : dim); ++i) {
+				ElementType span = bbox[i].high-bbox[i].low;
+				if (span>(1-EPS)*max_span) {
+					ElementType min_elem, max_elem;
+					computeMinMax(ind, count, cutfeat, min_elem, max_elem);
+					ElementType spread = max_elem-min_elem;;
+					if (spread>max_spread) {
+						cutfeat = i;
+						max_spread = spread;
+					}
+				}
+			}
+			// split in the middle
+			DistanceType split_val = (bbox[cutfeat].low+bbox[cutfeat].high)/2;
+			ElementType min_elem, max_elem;
+			computeMinMax(ind, count, cutfeat, min_elem, max_elem);
+
+			if (split_val<min_elem) cutval = min_elem;
+			else if (split_val>max_elem) cutval = max_elem;
+			else cutval = split_val;
+
+			IndexType lim1, lim2;
+			planeSplit(ind, count, cutfeat, cutval, lim1, lim2);
+
+			if (lim1>count/2) index = lim1;
+			else if (lim2<count/2) index = lim2;
+			else index = count/2;
+		}
+
+
+		/**
+		 *  Subdivide the list of points by a plane perpendicular on axe corresponding
+		 *  to the 'cutfeat' dimension at 'cutval' position.
+		 *
+		 *  On return:
+		 *  dataset[ind[0..lim1-1]][cutfeat]<cutval
+		 *  dataset[ind[lim1..lim2-1]][cutfeat]==cutval
+		 *  dataset[ind[lim2..count]][cutfeat]>cutval
+		 */
+		void planeSplit(IndexType* ind, const IndexType count, int cutfeat, DistanceType &cutval, IndexType& lim1, IndexType& lim2)
+		{
+			/* Move vector indices for left subtree to front of list. */
+			IndexType left = 0;
+			IndexType right = count-1;
+			for (;; ) {
+				while (left<=right && dataset_get(ind[left],cutfeat)<cutval) ++left;
+				while (right && left<=right && dataset_get(ind[right],cutfeat)>=cutval) --right;
+				if (left>right || !right) break;  // "!right" was added to support unsigned Index types
+				std::swap(ind[left], ind[right]);
+				++left;
+				--right;
+			}
+			/* If either list is empty, it means that all remaining features
+			 * are identical. Split in the middle to maintain a balanced tree.
+			 */
+			lim1 = left;
+			right = count-1;
+			for (;; ) {
+				while (left<=right && dataset_get(ind[left],cutfeat)<=cutval) ++left;
+				while (right && left<=right && dataset_get(ind[right],cutfeat)>cutval) --right;
+				if (left>right || !right) break;  // "!right" was added to support unsigned Index types
+				std::swap(ind[left], ind[right]);
+				++left;
+				--right;
+			}
+			lim2 = left;
+		}
+
+		DistanceType computeInitialDistances(const ElementType* vec, distance_vector_t& dists) const
+		{
+			assert(vec);
+			DistanceType distsq = DistanceType();
+
+			for (int i = 0; i < (DIM>0 ? DIM : dim); ++i) {
+				if (vec[i] < root_bbox[i].low) {
+					dists[i] = distance.accum_dist(vec[i], root_bbox[i].low, i);
+					distsq += dists[i];
+				}
+				if (vec[i] > root_bbox[i].high) {
+					dists[i] = distance.accum_dist(vec[i], root_bbox[i].high, i);
+					distsq += dists[i];
+				}
+			}
+
+			return distsq;
+		}
+
+		/**
+		 * Performs an exact search in the tree starting from a node.
+		 * \tparam RESULTSET Should be any ResultSet<DistanceType>
+		 */
+		template <class RESULTSET>
+		void searchLevel(RESULTSET& result_set, const ElementType* vec, const NodePtr node, DistanceType &mindistsq,
+						 distance_vector_t& dists, const float epsError) const
+		{
+			/* If this is a leaf node, then do check and return. */
+			if ((node->child1 == NULL)&&(node->child2 == NULL)) {
+				//count_leaf += (node->lr.right-node->lr.left);  // Removed since was neither used nor returned to the user.
+				DistanceType worst_dist = result_set.worstDist();
+				for (IndexType i=node->node_type.lr.left; i<node->node_type.lr.right; ++i) {
+					const IndexType index = vind[i];// reorder... : i;
+					DistanceType dist = distance(vec, index, (DIM>0 ? DIM : dim));
+					if (dist<worst_dist) {
+						result_set.addPoint(dist,vind[i]);
+					}
+				}
+				return;
+			}
+
+			/* Which child branch should be taken first? */
+			int idx = node->node_type.sub.divfeat;
+			ElementType val = vec[idx];
+			DistanceType diff1 = val - node->node_type.sub.divlow;
+			DistanceType diff2 = val - node->node_type.sub.divhigh;
+
+			NodePtr bestChild;
+			NodePtr otherChild;
+			DistanceType cut_dist;
+			if ((diff1+diff2)<0) {
+				bestChild = node->child1;
+				otherChild = node->child2;
+				cut_dist = distance.accum_dist(val, node->node_type.sub.divhigh, idx);
+			}
+			else {
+				bestChild = node->child2;
+				otherChild = node->child1;
+				cut_dist = distance.accum_dist( val, node->node_type.sub.divlow, idx);
+			}
+
+			/* Call recursively to search next level down. */
+			searchLevel(result_set, vec, bestChild, mindistsq, dists, epsError);
+
+			DistanceType dst = dists[idx];
+			mindistsq = mindistsq + cut_dist - dst;
+			dists[idx] = cut_dist;
+			if (mindistsq*epsError<=result_set.worstDist()) {
+				searchLevel(result_set, vec, otherChild, mindistsq, dists, epsError);
+			}
+			dists[idx] = dst;
+		}
+
+	public:
+		/**  Stores the index in a binary file.
+		  *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so when loading the index object it must be constructed associated to the same source of data points used while building it.
+		  * See the example: examples/saveload_example.cpp
+		  * \sa loadIndex  */
+		void saveIndex(FILE* stream)
+		{
+			save_value(stream, m_size);
+			save_value(stream, dim);
+			save_value(stream, root_bbox);
+			save_value(stream, m_leaf_max_size);
+			save_value(stream, vind);
+			save_tree(stream, root_node);
+		}
+
+		/**  Loads a previous index from a binary file.
+		  *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so the index object must be constructed associated to the same source of data points used while building the index.
+		  * See the example: examples/saveload_example.cpp
+		  * \sa loadIndex  */
+		void loadIndex(FILE* stream)
+		{
+			load_value(stream, m_size);
+			load_value(stream, dim);
+			load_value(stream, root_bbox);
+			load_value(stream, m_leaf_max_size);
+			load_value(stream, vind);
+			load_tree(stream, root_node);
+		}
+
+	};   // class KDTree
+
+
+	/** An L2-metric KD-tree adaptor for working with data directly stored in an Eigen Matrix, without duplicating the data storage.
+	  *  Each row in the matrix represents a point in the state space.
+	  *
+	  *  Example of usage:
+	  * \code
+	  * 	Eigen::Matrix<num_t,Dynamic,Dynamic>  mat;
+	  * 	// Fill out "mat"...
+	  *
+	  * 	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic> >  my_kd_tree_t;
+	  * 	const int max_leaf = 10;
+	  * 	my_kd_tree_t   mat_index(dimdim, mat, max_leaf );
+	  * 	mat_index.index->buildIndex();
+	  * 	mat_index.index->...
+	  * \endcode
+	  *
+	  *  \tparam DIM If set to >0, it specifies a compile-time fixed dimensionality for the points in the data set, allowing more compiler optimizations.
+	  *  \tparam Distance The distance metric to use: nanoflann::metric_L1, nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
+	  */
+	template <class MatrixType, int DIM = -1, class Distance = nanoflann::metric_L2>
+	struct KDTreeEigenMatrixAdaptor
+	{
+		typedef KDTreeEigenMatrixAdaptor<MatrixType,DIM,Distance> self_t;
+		typedef typename MatrixType::Scalar              num_t;
+		typedef typename MatrixType::Index IndexType;
+		typedef typename Distance::template traits<num_t,self_t>::distance_t metric_t;
+		typedef KDTreeSingleIndexAdaptor< metric_t,self_t,DIM,IndexType>  index_t;
+
+		index_t* index; //! The kd-tree index for the user to call its methods as usual with any other FLANN index.
+
+		/// Constructor: takes a const ref to the matrix object with the data points
+		KDTreeEigenMatrixAdaptor(const int dimensionality, const MatrixType &mat, const int leaf_max_size = 10) : m_data_matrix(mat)
+		{
+			const IndexType dims = mat.cols();
+			if (dims!=dimensionality) throw std::runtime_error("Error: 'dimensionality' must match column count in data matrix");
+			if (DIM>0 && static_cast<int>(dims)!=DIM)
+				throw std::runtime_error("Data set dimensionality does not match the 'DIM' template argument");
+			index = new index_t( dims, *this /* adaptor */, nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size ) );
+			index->buildIndex();
+		}
+	private:
+		/** Hidden copy constructor, to disallow copying this class (Not implemented) */
+		KDTreeEigenMatrixAdaptor(const self_t&);
+	public:
+
+		~KDTreeEigenMatrixAdaptor() {
+			delete index;
+		}
+
+		const MatrixType &m_data_matrix;
+
+		/** Query for the \a num_closest closest points to a given point (entered as query_point[0:dim-1]).
+		  *  Note that this is a short-cut method for index->findNeighbors().
+		  *  The user can also call index->... methods as desired.
+		  * \note nChecks_IGNORED is ignored but kept for compatibility with the original FLANN interface.
+		  */
+		inline void query(const num_t *query_point, const size_t num_closest, IndexType *out_indices, num_t *out_distances_sq, const int /* nChecks_IGNORED */ = 10) const
+		{
+			nanoflann::KNNResultSet<num_t,IndexType> resultSet(num_closest);
+			resultSet.init(out_indices, out_distances_sq);
+			index->findNeighbors(resultSet, query_point, nanoflann::SearchParams());
+		}
+
+		/** @name Interface expected by KDTreeSingleIndexAdaptor
+		  * @{ */
+
+		const self_t & derived() const {
+			return *this;
+		}
+		self_t & derived()       {
+			return *this;
+		}
+
+		// Must return the number of data points
+		inline size_t kdtree_get_point_count() const {
+			return m_data_matrix.rows();
+		}
+
+		// Returns the L2 distance between the vector "p1[0:size-1]" and the data point with index "idx_p2" stored in the class:
+		inline num_t kdtree_distance(const num_t *p1, const IndexType idx_p2,IndexType size) const
+		{
+			num_t s=0;
+			for (IndexType i=0; i<size; i++) {
+				const num_t d= p1[i]-m_data_matrix.coeff(idx_p2,i);
+				s+=d*d;
+			}
+			return s;
+		}
+
+		// Returns the dim'th component of the idx'th point in the class:
+		inline num_t kdtree_get_pt(const IndexType idx, int dim) const {
+			return m_data_matrix.coeff(idx,IndexType(dim));
+		}
+
+		// Optional bounding-box computation: return false to default to a standard bbox computation loop.
+		//   Return true if the BBOX was already computed by the class and returned in "bb" so it can be avoided to redo it again.
+		//   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3 for point clouds)
+		template <class BBOX>
+		bool kdtree_get_bbox(BBOX& /*bb*/) const {
+			return false;
+		}
+
+		/** @} */
+
+	}; // end of KDTreeEigenMatrixAdaptor
+	/** @} */
+
+/** @} */ // end of grouping
+} // end of NS
+
+
+#endif /* NANOFLANN_HPP_ */

--- a/interface/prettyprint.hpp
+++ b/interface/prettyprint.hpp
@@ -1,0 +1,445 @@
+//          Copyright Louis Delacroix 2010 - 2014.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+// A pretty printing library for C++
+//
+// Usage:
+// Include this header, and operator<< will "just work".
+
+#ifndef H_PRETTY_PRINT
+#define H_PRETTY_PRINT
+
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <ostream>
+#include <set>
+#include <tuple>
+#include <type_traits>
+#include <unordered_set>
+#include <utility>
+#include <valarray>
+
+namespace pretty_print
+{
+    namespace detail
+    {
+        // SFINAE type trait to detect whether T::const_iterator exists.
+
+        struct sfinae_base
+        {
+            using yes = char;
+            using no  = yes[2];
+        };
+
+        template <typename T>
+        struct has_const_iterator : private sfinae_base
+        {
+        private:
+            template <typename C> static yes & test(typename C::const_iterator*);
+            template <typename C> static no  & test(...);
+        public:
+            static const bool value = sizeof(test<T>(nullptr)) == sizeof(yes);
+            using type =  T;
+        };
+
+        template <typename T>
+        struct has_begin_end : private sfinae_base
+        {
+        private:
+            template <typename C>
+            static yes & f(typename std::enable_if<
+                std::is_same<decltype(static_cast<typename C::const_iterator(C::*)() const>(&C::begin)),
+                             typename C::const_iterator(C::*)() const>::value>::type *);
+
+            template <typename C> static no & f(...);
+
+            template <typename C>
+            static yes & g(typename std::enable_if<
+                std::is_same<decltype(static_cast<typename C::const_iterator(C::*)() const>(&C::end)),
+                             typename C::const_iterator(C::*)() const>::value, void>::type*);
+
+            template <typename C> static no & g(...);
+
+        public:
+            static bool const beg_value = sizeof(f<T>(nullptr)) == sizeof(yes);
+            static bool const end_value = sizeof(g<T>(nullptr)) == sizeof(yes);
+        };
+
+    }  // namespace detail
+
+
+    // Holds the delimiter values for a specific character type
+
+    template <typename TChar>
+    struct delimiters_values
+    {
+        using char_type = TChar;
+        const char_type * prefix;
+        const char_type * delimiter;
+        const char_type * postfix;
+    };
+
+
+    // Defines the delimiter values for a specific container and character type
+
+    template <typename T, typename TChar>
+    struct delimiters
+    {
+        using type = delimiters_values<TChar>;
+        static const type values; 
+    };
+
+
+    // Functor to print containers. You can use this directly if you want
+    // to specificy a non-default delimiters type. The printing logic can
+    // be customized by specializing the nested template.
+
+    template <typename T,
+              typename TChar = char,
+              typename TCharTraits = ::std::char_traits<TChar>,
+              typename TDelimiters = delimiters<T, TChar>>
+    struct print_container_helper
+    {
+        using delimiters_type = TDelimiters;
+        using ostream_type = std::basic_ostream<TChar, TCharTraits>;
+
+        template <typename U>
+        struct printer
+        {
+            static void print_body(const U & c, ostream_type & stream)
+            {
+                using std::begin;
+                using std::end;
+
+                auto it = begin(c);
+                const auto the_end = end(c);
+
+                if (it != the_end)
+                {
+                    for ( ; ; )
+                    {
+                        stream << *it;
+
+                    if (++it == the_end) break;
+
+                    if (delimiters_type::values.delimiter != NULL)
+                        stream << delimiters_type::values.delimiter;
+                    }
+                }
+            }
+        };
+
+        print_container_helper(const T & container)
+        : container_(container)
+        { }
+
+        inline void operator()(ostream_type & stream) const
+        {
+            if (delimiters_type::values.prefix != NULL)
+                stream << delimiters_type::values.prefix;
+
+            printer<T>::print_body(container_, stream);
+
+            if (delimiters_type::values.postfix != NULL)
+                stream << delimiters_type::values.postfix;
+        }
+
+    private:
+        const T & container_;
+    };
+
+    // Specialization for pairs
+
+    template <typename T, typename TChar, typename TCharTraits, typename TDelimiters>
+    template <typename T1, typename T2>
+    struct print_container_helper<T, TChar, TCharTraits, TDelimiters>::printer<std::pair<T1, T2>>
+    {
+        using ostream_type = print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
+
+        static void print_body(const std::pair<T1, T2> & c, ostream_type & stream)
+        {
+            stream << c.first;
+            if (print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter != NULL)
+                stream << print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter;
+            stream << c.second;
+        }
+    };
+
+    // Specialization for tuples
+
+    template <typename T, typename TChar, typename TCharTraits, typename TDelimiters>
+    template <typename ...Args>
+    struct print_container_helper<T, TChar, TCharTraits, TDelimiters>::printer<std::tuple<Args...>>
+    {
+        using ostream_type = print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
+        using element_type = std::tuple<Args...>;
+
+        template <std::size_t I> struct Int { };
+
+        static void print_body(const element_type & c, ostream_type & stream)
+        {
+            tuple_print(c, stream, Int<0>());
+        }
+
+        static void tuple_print(const element_type &, ostream_type &, Int<sizeof...(Args)>)
+        {
+        }
+
+        static void tuple_print(const element_type & c, ostream_type & stream,
+                                typename std::conditional<sizeof...(Args) != 0, Int<0>, std::nullptr_t>::type)
+        {
+            stream << std::get<0>(c);
+            tuple_print(c, stream, Int<1>());
+        }
+
+        template <std::size_t N>
+        static void tuple_print(const element_type & c, ostream_type & stream, Int<N>)
+        {
+            if (print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter != NULL)
+                stream << print_container_helper<T, TChar, TCharTraits, TDelimiters>::delimiters_type::values.delimiter;
+
+            stream << std::get<N>(c);
+
+            tuple_print(c, stream, Int<N + 1>());
+        }
+    };
+
+    // Prints a print_container_helper to the specified stream.
+
+    template<typename T, typename TChar, typename TCharTraits, typename TDelimiters>
+    inline std::basic_ostream<TChar, TCharTraits> & operator<<(
+        std::basic_ostream<TChar, TCharTraits> & stream,
+        const print_container_helper<T, TChar, TCharTraits, TDelimiters> & helper)
+    {
+        helper(stream);
+        return stream;
+    }
+
+
+    // Basic is_container template; specialize to derive from std::true_type for all desired container types
+
+    template <typename T>
+    struct is_container : public std::integral_constant<bool,
+                                                        detail::has_const_iterator<T>::value &&
+                                                        detail::has_begin_end<T>::beg_value  &&
+                                                        detail::has_begin_end<T>::end_value> { };
+
+    template <typename T, std::size_t N>
+    struct is_container<T[N]> : std::true_type { };
+
+    template <std::size_t N>
+    struct is_container<char[N]> : std::false_type { };
+
+    template <typename T>
+    struct is_container<std::valarray<T>> : std::true_type { };
+
+    template <typename T1, typename T2>
+    struct is_container<std::pair<T1, T2>> : std::true_type { };
+
+    template <typename ...Args>
+    struct is_container<std::tuple<Args...>> : std::true_type { };
+
+
+    // Default delimiters
+
+    template <typename T> struct delimiters<T, char> { static const delimiters_values<char> values; };
+    template <typename T> const delimiters_values<char> delimiters<T, char>::values = { "[", ", ", "]" };
+    template <typename T> struct delimiters<T, wchar_t> { static const delimiters_values<wchar_t> values; };
+    template <typename T> const delimiters_values<wchar_t> delimiters<T, wchar_t>::values = { L"[", L", ", L"]" };
+
+
+    // Delimiters for (multi)set and unordered_(multi)set
+
+    template <typename T, typename TComp, typename TAllocator>
+    struct delimiters< ::std::set<T, TComp, TAllocator>, char> { static const delimiters_values<char> values; };
+
+    template <typename T, typename TComp, typename TAllocator>
+    const delimiters_values<char> delimiters< ::std::set<T, TComp, TAllocator>, char>::values = { "{", ", ", "}" };
+
+    template <typename T, typename TComp, typename TAllocator>
+    struct delimiters< ::std::set<T, TComp, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
+
+    template <typename T, typename TComp, typename TAllocator>
+    const delimiters_values<wchar_t> delimiters< ::std::set<T, TComp, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
+
+    template <typename T, typename TComp, typename TAllocator>
+    struct delimiters< ::std::multiset<T, TComp, TAllocator>, char> { static const delimiters_values<char> values; };
+
+    template <typename T, typename TComp, typename TAllocator>
+    const delimiters_values<char> delimiters< ::std::multiset<T, TComp, TAllocator>, char>::values = { "{", ", ", "}" };
+
+    template <typename T, typename TComp, typename TAllocator>
+    struct delimiters< ::std::multiset<T, TComp, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
+
+    template <typename T, typename TComp, typename TAllocator>
+    const delimiters_values<wchar_t> delimiters< ::std::multiset<T, TComp, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
+
+    template <typename T, typename THash, typename TEqual, typename TAllocator>
+    struct delimiters< ::std::unordered_set<T, THash, TEqual, TAllocator>, char> { static const delimiters_values<char> values; };
+
+    template <typename T, typename THash, typename TEqual, typename TAllocator>
+    const delimiters_values<char> delimiters< ::std::unordered_set<T, THash, TEqual, TAllocator>, char>::values = { "{", ", ", "}" };
+
+    template <typename T, typename THash, typename TEqual, typename TAllocator>
+    struct delimiters< ::std::unordered_set<T, THash, TEqual, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
+
+    template <typename T, typename THash, typename TEqual, typename TAllocator>
+    const delimiters_values<wchar_t> delimiters< ::std::unordered_set<T, THash, TEqual, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
+
+    template <typename T, typename THash, typename TEqual, typename TAllocator>
+    struct delimiters< ::std::unordered_multiset<T, THash, TEqual, TAllocator>, char> { static const delimiters_values<char> values; };
+
+    template <typename T, typename THash, typename TEqual, typename TAllocator>
+    const delimiters_values<char> delimiters< ::std::unordered_multiset<T, THash, TEqual, TAllocator>, char>::values = { "{", ", ", "}" };
+
+    template <typename T, typename THash, typename TEqual, typename TAllocator>
+    struct delimiters< ::std::unordered_multiset<T, THash, TEqual, TAllocator>, wchar_t> { static const delimiters_values<wchar_t> values; };
+
+    template <typename T, typename THash, typename TEqual, typename TAllocator>
+    const delimiters_values<wchar_t> delimiters< ::std::unordered_multiset<T, THash, TEqual, TAllocator>, wchar_t>::values = { L"{", L", ", L"}" };
+
+
+    // Delimiters for pair and tuple
+
+    template <typename T1, typename T2> struct delimiters<std::pair<T1, T2>, char> { static const delimiters_values<char> values; };
+    template <typename T1, typename T2> const delimiters_values<char> delimiters<std::pair<T1, T2>, char>::values = { "(", ", ", ")" };
+    template <typename T1, typename T2> struct delimiters< ::std::pair<T1, T2>, wchar_t> { static const delimiters_values<wchar_t> values; };
+    template <typename T1, typename T2> const delimiters_values<wchar_t> delimiters< ::std::pair<T1, T2>, wchar_t>::values = { L"(", L", ", L")" };
+
+    template <typename ...Args> struct delimiters<std::tuple<Args...>, char> { static const delimiters_values<char> values; };
+    template <typename ...Args> const delimiters_values<char> delimiters<std::tuple<Args...>, char>::values = { "(", ", ", ")" };
+    template <typename ...Args> struct delimiters< ::std::tuple<Args...>, wchar_t> { static const delimiters_values<wchar_t> values; };
+    template <typename ...Args> const delimiters_values<wchar_t> delimiters< ::std::tuple<Args...>, wchar_t>::values = { L"(", L", ", L")" };
+
+
+    // Type-erasing helper class for easy use of custom delimiters.
+    // Requires TCharTraits = std::char_traits<TChar> and TChar = char or wchar_t, and MyDelims needs to be defined for TChar.
+    // Usage: "cout << pretty_print::custom_delims<MyDelims>(x)".
+
+    struct custom_delims_base
+    {
+        virtual ~custom_delims_base() { }
+        virtual std::ostream & stream(::std::ostream &) = 0;
+        virtual std::wostream & stream(::std::wostream &) = 0;
+    };
+
+    template <typename T, typename Delims>
+    struct custom_delims_wrapper : custom_delims_base
+    {
+        custom_delims_wrapper(const T & t_) : t(t_) { }
+
+        std::ostream & stream(std::ostream & s)
+        {
+            return s << print_container_helper<T, char, std::char_traits<char>, Delims>(t);
+        }
+
+        std::wostream & stream(std::wostream & s)
+        {
+            return s << print_container_helper<T, wchar_t, std::char_traits<wchar_t>, Delims>(t);
+        }
+
+    private:
+        const T & t;
+    };
+
+    template <typename Delims>
+    struct custom_delims
+    {
+        template <typename Container>
+        custom_delims(const Container & c) : base(new custom_delims_wrapper<Container, Delims>(c)) { }
+
+        std::unique_ptr<custom_delims_base> base;
+    };
+
+    template <typename TChar, typename TCharTraits, typename Delims>
+    inline std::basic_ostream<TChar, TCharTraits> & operator<<(std::basic_ostream<TChar, TCharTraits> & s, const custom_delims<Delims> & p)
+    {
+        return p.base->stream(s);
+    }
+
+
+    // A wrapper for a C-style array given as pointer-plus-size.
+    // Usage: std::cout << pretty_print_array(arr, n) << std::endl;
+
+    template<typename T>
+    struct array_wrapper_n
+    {
+        typedef const T * const_iterator;
+        typedef T value_type;
+
+        array_wrapper_n(const T * const a, size_t n) : _array(a), _n(n) { }
+        inline const_iterator begin() const { return _array; }
+        inline const_iterator end() const { return _array + _n; }
+
+    private:
+        const T * const _array;
+        size_t _n;
+    };
+
+
+    // A wrapper for hash-table based containers that offer local iterators to each bucket.
+    // Usage: std::cout << bucket_print(m, 4) << std::endl;  (Prints bucket 5 of container m.)
+
+    template <typename T>
+    struct bucket_print_wrapper
+    {
+        typedef typename T::const_local_iterator const_iterator;
+        typedef typename T::size_type size_type;
+
+        const_iterator begin() const
+        {
+            return m_map.cbegin(n);
+        }
+
+        const_iterator end() const
+        {
+            return m_map.cend(n);
+        }
+
+        bucket_print_wrapper(const T & m, size_type bucket) : m_map(m), n(bucket) { }
+
+    private:
+        const T & m_map;
+        const size_type n;
+    };
+
+}   // namespace pretty_print
+
+
+// Global accessor functions for the convenience wrappers
+
+template<typename T>
+inline pretty_print::array_wrapper_n<T> pretty_print_array(const T * const a, size_t n)
+{
+    return pretty_print::array_wrapper_n<T>(a, n);
+}
+
+template <typename T> pretty_print::bucket_print_wrapper<T>
+bucket_print(const T & m, typename T::size_type n)
+{
+    return pretty_print::bucket_print_wrapper<T>(m, n);
+}
+
+
+// Main magic entry point: An overload snuck into namespace std.
+// Can we do better?
+
+namespace std
+{
+    // Prints a container to the stream using default delimiters
+
+    template<typename T, typename TChar, typename TCharTraits>
+    inline typename enable_if< ::pretty_print::is_container<T>::value,
+                              basic_ostream<TChar, TCharTraits> &>::type
+    operator<<(basic_ostream<TChar, TCharTraits> & stream, const T & container)
+    {
+        return stream << ::pretty_print::print_container_helper<T, TChar, TCharTraits>(container);
+    }
+}
+
+
+
+#endif  // H_PRETTY_PRINT

--- a/scripts/TrgEffStudies.py
+++ b/scripts/TrgEffStudies.py
@@ -40,8 +40,11 @@ trg_namesN_v = vector("string")()
 for trg_nameN in trg_namesN: trg_namesN_v.push_back(trg_nameN)
 
 # to parse variables to the anlyzer
-config = {"jets_branch_name": "Jets",
-          "hlt_names": trg_names, 
+config = {"eventInfo_branch_name" : "EventInfo",
+          "jets_branch_name": "Jets",
+          "muons_branch_name" : "Muons",
+          "electrons_branch_name" : "Electron",
+          "met_branch_name" : "MET",
           "n_gen_events":0,
           "xsec_br" : 0,
           "matcheff": 0,
@@ -115,13 +118,13 @@ for sname in snames:
     selector.addOperator(FolderOperator(alp.Event)("4CSVM_noTrg"))
     selector.addOperator(JetPlotterOperator(alp.Event)("pfCombinedInclusiveSecondaryVertexV2BJetTags"))
     selector.addOperator(CounterOperator(alp.Event)())
-    selector.addOperator(EventWriterOperator(alp.Event)())
+    selector.addOperator(EventWriterOperator(alp.Event)(json.dumps(config)))
 
     selector.addOperator(TriggerOperator(alp.Event)(trg_namesN_v)) #to select on hh4b trigger
     selector.addOperator(FolderOperator(alp.Event)("4CSVM_Trg"))
     selector.addOperator(JetPlotterOperator(alp.Event)("pfCombinedInclusiveSecondaryVertexV2BJetTags"))
     selector.addOperator(CounterOperator(alp.Event)())
-    selector.addOperator(EventWriterOperator(alp.Event)())
+    selector.addOperator(EventWriterOperator(alp.Event)(json.dumps(config)))
 
     #create tChain and process each files
     tchain = TChain("ntuple/tree")

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,5 +1,6 @@
 
 #include "Analysis/alp_analysis/interface/Event.h"
+#include "Analysis/alp_analysis/interface/Hemisphere.h"
 #include "Analysis/alp_analysis/interface/ComposableSelector.h"
 #include "Analysis/alp_analysis/interface/BaseOperator.h"
 #include "Analysis/alp_analysis/interface/FolderOperator.h"
@@ -14,6 +15,11 @@
 #include "Analysis/alp_analysis/interface/JetPlotterOperator.h"
 #include "Analysis/alp_analysis/interface/DiJetPlotterOperator.h"
 #include "Analysis/alp_analysis/interface/EventWriterOperator.h"
+
+#include "Analysis/alp_analysis/interface/ThrustFinderOperator.h"
+#include "Analysis/alp_analysis/interface/HemisphereProducerOperator.h"
+#include "Analysis/alp_analysis/interface/HemisphereMixerOperator.h"
+#include "Analysis/alp_analysis/interface/MixedEventWriterOperator.h"
 
 
 namespace {
@@ -36,9 +42,14 @@ namespace {
     JetPlotterOperator<EventBase> jet_plotter_operator; 
     DiJetPlotterOperator<EventBase> di_jet_plotter_operator; 
     EventWriterOperator<EventBase> event_writer_operator; 
+    ThrustFinderOperator<EventBase> thrust_finder_operator;
+    HemisphereProducerOperator<EventBase> hemisphere_producer_operator;
+    HemisphereMixerOperator<EventBase> hemisphere_mixer_operator;
+    MixedEventWriterOperator<EventBase> mixed_event_writer_operator;
   };
 
   struct event_formats {
+    alp::Hemisphere alp_hemisphere;
     instances<alp::Event> instances_alp_event;
     };
 

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
   <class name="alp::Event"/>    
+  <class name="alp::Hemisphere"/>    
   <class pattern="ComposableSelector*"/>    
   <class pattern="FolderOperator<*>"/>    
   <class pattern="CounterOperator<*>"/>    
@@ -13,4 +14,8 @@
   <class pattern="JetPlotterOperator<*>"/>     
   <class pattern="DiJetPlotterOperator<*>"/>    
   <class pattern="EventWriterOperator<*>"/> 
+  <class pattern="ThrustFinderOperator<*>"/> 
+  <class pattern="HemisphereProducerOperator<*>"/> 
+  <class pattern="HemisphereMixerOperator<*>"/> 
+  <class pattern="MixedEventWriterOperator<*>"/> 
 </lcgdict>  


### PR DESCRIPTION
This PR adds the modules required for doing event mixing for background estimation. The Python script has not been adapted yet. Header only libraries nanoflann and prettyprint because they were required by the event mixing modules.

In addition, tries to solve #20, synchronizing the output of ALPHA (input of alp_analysis) with the EventWriterOperator output.
