### PR TITLE
improve Event Weight handling

### DIFF
--- a/interface/BTagFilterOperator.h
+++ b/interface/BTagFilterOperator.h
@@ -61,8 +61,9 @@
             w_btag *= btcr.eval(jf, ev.jets_.at(i).p4_.Eta(), ev.jets_.at(i).p4_.Pt(), ev.jets_.at(i).disc(disc_));
           }
         }
-        // add weight to event info and multiply EventWeight to bTag.
+        // add weight to event info
         ev.eventInfo_.weightPairs_.emplace_back("BTagWeight",w_btag);
+
         return true;
       }
 

--- a/interface/DiJetPlotterOperator.h
+++ b/interface/DiJetPlotterOperator.h
@@ -14,8 +14,7 @@ template <class EventClass> class DiJetPlotterOperator : public BaseOperator<Eve
   public:
  
     std::vector<std::string> weights_;
-    std::string btagWname = "BTagWeight"; //make it more general?
-
+ 
     TH1D h_H0_mass   {"h_H0_mass",   "leading di-jet mass"    , 300, 0., 900.};
     TH1D h_H0_pt     {"h_H0_pt"  ,   "leading di-jet pt"      , 300, 0., 900.};
     TH1D h_H0_eta    {"h_H0_eta" ,   "leading di-jet eta"     , 100, -4.0, 4.0};
@@ -127,9 +126,7 @@ template <class EventClass> class DiJetPlotterOperator : public BaseOperator<Eve
 
       float w = 1.0;
       w*=ev.eventInfo_.eventWeight(weights_);
-      if (ev.eventInfo_.hasWeight(btagWname)) {
-        w*=ev.eventInfo_.getWeight(btagWname);
-      }   
+
      // debug - jets already sorted accordingly to pairing
       h_H0_mass.Fill(ev.dijets_.at(0).mass(), w);
       h_H0_pt.Fill(ev.dijets_.at(0).pt(), w);

--- a/interface/EventWriterOperator.h
+++ b/interface/EventWriterOperator.h
@@ -20,6 +20,7 @@ template <class EventClass> class EventWriterOperator : public BaseOperator<Even
     std::vector<std::string> weights_;
 
     // variables to save in branches
+    float_t evtWeight = 1.;
     std::vector<alp::Jet> * jets_ptr = nullptr;
     std::vector<alp::Lepton> * muons_ptr = nullptr;
     std::vector<alp::Lepton> * electrons_ptr = nullptr;
@@ -41,6 +42,8 @@ template <class EventClass> class EventWriterOperator : public BaseOperator<Even
     virtual ~EventWriterOperator() {}
 
     virtual void init(TDirectory * tdir) {
+
+      tree_.Branch("evtWeight", &evtWeight, "evtWeight/F");
 
       if (config_.find("eventInfo_branch_name") != config_.end()) {
         tree_.Branch(config_.at("eventInfo_branch_name").template get<std::string>().c_str(),
@@ -87,6 +90,9 @@ template <class EventClass> class EventWriterOperator : public BaseOperator<Even
     virtual bool process( EventClass & ev ) {
 
       // to fill tree redirect pointers that where read
+      evtWeight = 1.;
+      evtWeight *= ev.eventInfo_.eventWeight(weights_); //multiplied all weights from cfg
+
       eventInfo_ptr = dynamic_cast<alp::EventInfo *>(&ev.eventInfo_); 
       jets_ptr = dynamic_cast<std::vector<alp::Jet> *>(&ev.jets_); 
       muons_ptr = dynamic_cast<std::vector<alp::Lepton> *>(&ev.muons_); 

--- a/interface/JetPlotterOperator.h
+++ b/interface/JetPlotterOperator.h
@@ -14,7 +14,6 @@ template <class EventClass> class JetPlotterOperator : public BaseOperator<Event
  
     std::string disc_;
     std::vector<std::string> weights_;
-    std::string btagWname = "BTagWeight"; //make it more general?
 
     std::vector<std::size_t> j_sortInd_;
 
@@ -128,9 +127,6 @@ template <class EventClass> class JetPlotterOperator : public BaseOperator<Event
     virtual bool process( EventClass & ev ) {
       float w = 1.0;
       w*=ev.eventInfo_.eventWeight(weights_);
-      if (ev.eventInfo_.hasWeight(btagWname)) {
-        w*=ev.eventInfo_.getWeight(btagWname);
-      }   
 
       h_nevts.Fill(0.5, w);
 

--- a/interface/MiscellPlotterOperator.h
+++ b/interface/MiscellPlotterOperator.h
@@ -14,7 +14,6 @@ template <class EventClass> class MiscellPlotterOperator : public BaseOperator<E
  
     std::string disc_;
     std::vector<std::string> weights_;
-    std::string btagWname = "BTagWeight"; //make it more general?
 
     std::vector<std::size_t> j_sortInd_;
 
@@ -56,9 +55,6 @@ template <class EventClass> class MiscellPlotterOperator : public BaseOperator<E
 
       float w = 1.0;
       w *= ev.eventInfo_.eventWeight(weights_); 
-      if (ev.eventInfo_.hasWeight(btagWname)) {
-        w*=ev.eventInfo_.getWeight(btagWname);
-      }   
 
       h_mu_n.Fill(ev.muons_.size(), w);
       h_met_pt.Fill(ev.met_.pt(), w);

--- a/scripts/BaselineSelector.py
+++ b/scripts/BaselineSelector.py
@@ -43,7 +43,7 @@ if not args.oDir: oDir = "/lustre/cmswork/hh/alp_baseSelector/data_def"
 else: oDir = args.oDir
 
 data_path = "{}/src/Analysis/alp_analysis/data/".format(os.environ["CMSSW_BASE"])
-weights = {'EventWeight'}  #weights to be applied - EventWeight, PUWeight, GenWeight
+weights = {'PUWeight', 'GenWeight', 'BTagWeight'}  #weights to be applied
 # ---------------
 
 if not os.path.exists(oDir): os.mkdir(oDir)
@@ -146,7 +146,7 @@ for sname in snames:
     selector.addOperator(FolderOperator(alp.Event)("pair"))
     selector.addOperator(JetPlotterOperator(alp.Event)("pfCombinedInclusiveSecondaryVertexV2BJetTags",weights_v))        
     selector.addOperator(DiJetPlotterOperator(alp.Event)(weights_v))
-    selector.addOperator(EventWriterOperator(alp.Event)(json_str))
+    selector.addOperator(EventWriterOperator(alp.Event)(json_str,weights_v))
     selector.addOperator(ThrustFinderOperator(alp.Event)())
     selector.addOperator(HemisphereProducerOperator(alp.Event)())
     selector.addOperator(HemisphereWriterOperator(alp.Event)())

--- a/scripts/GetPlainTree.py
+++ b/scripts/GetPlainTree.py
@@ -41,7 +41,7 @@ if not args.oDir: oDir = "./output/test"
 else: oDir = args.oDir
 
 data_path = "{}/src/Analysis/alp_analysis/data/".format(os.environ["CMSSW_BASE"])
-weights = {'EventWeight'}  #weights to be applied - EventWeight, PUWeight, GenWeight
+weights = {'PUWeight', 'GenWeight', 'BTagWeight'}  #weights to be applied - EventWeight, PUWeight, GenWeight
 # ---------------
 
 if not os.path.exists(oDir): os.mkdir(oDir)

--- a/scripts/MixingSelector.py
+++ b/scripts/MixingSelector.py
@@ -45,7 +45,7 @@ else: iDir += args.iDir
 if not args.oDir: oDir = "./output/mixSel_sig_def"
 else: oDir = args.oDir
 data_path = "{}/src/Analysis/alp_analysis/data/".format(os.environ["CMSSW_BASE"])
-weights = {'EventWeight'}  #weights to be applied - EventWeight, PUWeight, GenWeight
+weights = {'PUWeight', 'GenWeight', 'BTagWeight'}  #weights to be applied - EventWeight, PUWeight, GenWeight
 # ---------------
 
 if not os.path.exists(oDir): os.mkdir(oDir)

--- a/scripts/TrgEffStudies.py
+++ b/scripts/TrgEffStudies.py
@@ -33,7 +33,7 @@ iDir       = '/lustre/cmswork/hh/alpha_ntuples/'
 ntuplesVer = 'v1_20161028'
 oDir       = './output/trg_mc_def'
 data_path = "{}/src/Analysis/alp_analysis/data/".format(os.environ["CMSSW_BASE"])
-weights = {'EventWeight'} #weights to be applied - EventWeight, PUWeight, GenWeight
+weights = {'PUWeight', 'GenWeight', 'BTagWeight'} #weights to be applied - EventWeight, PUWeight, GenWeight
 # ---------------
 
 if not os.path.exists(oDir): os.mkdir(oDir)


### PR DESCRIPTION
3 main changes:
- removed the hardcoded "BTagWeight" inside the plotterOperator. 
The BTagWeight is always added in the BTagFilterOperator but it is read only if specified in the weights_ list.
- simple event weight branch added in the output. This simplify the reading of alp ntuples and the application of event weight.
- moved from "EventWeight" to detailed weights list in the scipts. This avoid confusion and clearify which weights are applied. Possible action on ALPHA: remove the "EventWeight" inside EventInfo.