### PR TITLE
Add btag sf systematic variations, fix eta range (sf=1 if eta>2.4)

### DIFF
--- a/interface/BTagCalibrationStandalone.h
+++ b/interface/BTagCalibrationStandalone.h
@@ -1,151 +1,189 @@
 #ifndef BTagEntry_H
 #define BTagEntry_H
+
 /**
-*
-* BTagEntry
-*
-* Represents one pt- or discriminator-dependent calibration function.
-*
-* measurement_type: e.g. comb, ttbar, di-mu, boosted, ...
-* sys_type: e.g. central, plus, minus, plus_JEC, plus_JER, ...
-*
-* Everything is converted into a function, as it is easiest to store it in a
-* txt or json file.
-*
-************************************************************/
+ *
+ * BTagEntry
+ *
+ * Represents one pt- or discriminator-dependent calibration function.
+ *
+ * measurement_type:    e.g. comb, ttbar, di-mu, boosted, ...
+ * sys_type:            e.g. central, plus, minus, plus_JEC, plus_JER, ...
+ *
+ * Everything is converted into a function, as it is easiest to store it in a
+ * txt or json file.
+ *
+ ************************************************************/
+
 #include <string>
 #include <TF1.h>
 #include <TH1.h>
+
+
 class BTagEntry
 {
 public:
-enum OperatingPoint {
-OP_LOOSE=0,
-OP_MEDIUM=1,
-OP_TIGHT=2,
-OP_RESHAPING=3,
+  enum OperatingPoint {
+    OP_LOOSE=0,
+    OP_MEDIUM=1,
+    OP_TIGHT=2,
+    OP_RESHAPING=3,
+  };
+  enum JetFlavor {
+    FLAV_B=0,
+    FLAV_C=1,
+    FLAV_UDSG=2,
+  };
+  struct Parameters {
+    OperatingPoint operatingPoint;
+    std::string measurementType;
+    std::string sysType;
+    JetFlavor jetFlavor;
+    float etaMin;
+    float etaMax;
+    float ptMin;
+    float ptMax;
+    float discrMin;
+    float discrMax;
+
+    // default constructor
+    Parameters(
+      OperatingPoint op=OP_TIGHT,
+      std::string measurement_type="comb",
+      std::string sys_type="central",
+      JetFlavor jf=FLAV_B,
+      float eta_min=-99999.,
+      float eta_max=99999.,
+      float pt_min=0.,
+      float pt_max=99999.,
+      float discr_min=0.,
+      float discr_max=99999.
+    );
+
+  };
+
+  BTagEntry() {}
+  BTagEntry(const std::string &csvLine);
+  BTagEntry(const std::string &func, Parameters p);
+  BTagEntry(const TF1* func, Parameters p);
+  BTagEntry(const TH1* histo, Parameters p);
+  ~BTagEntry() {}
+  static std::string makeCSVHeader();
+  std::string makeCSVLine() const;
+  static std::string trimStr(std::string str);
+
+  // public, no getters needed
+  std::string formula;
+  Parameters params;
+
 };
-enum JetFlavor {
-FLAV_B=0,
-FLAV_C=1,
-FLAV_UDSG=2,
-};
-struct Parameters {
-OperatingPoint operatingPoint;
-std::string measurementType;
-std::string sysType;
-JetFlavor jetFlavor;
-float etaMin;
-float etaMax;
-float ptMin;
-float ptMax;
-float discrMin;
-float discrMax;
-// default constructor
-Parameters(
-OperatingPoint op=OP_TIGHT,
-std::string measurement_type="comb",
-std::string sys_type="central",
-JetFlavor jf=FLAV_B,
-float eta_min=-99999.,
-float eta_max=99999.,
-float pt_min=0.,
-float pt_max=99999.,
-float discr_min=0.,
-float discr_max=99999.
-);
-};
-BTagEntry() {}
-BTagEntry(const std::string &csvLine);
-BTagEntry(const std::string &func, Parameters p);
-BTagEntry(const TF1* func, Parameters p);
-BTagEntry(const TH1* histo, Parameters p);
-~BTagEntry() {}
-static std::string makeCSVHeader();
-std::string makeCSVLine() const;
-static std::string trimStr(std::string str);
-// public, no getters needed
-std::string formula;
-Parameters params;
-};
-#endif // BTagEntry_H
+
+#endif  // BTagEntry_H
+
+
 #ifndef BTagCalibration_H
 #define BTagCalibration_H
+
 /**
-* BTagCalibration
-*
-* The 'hierarchy' of stored information is this:
-* - by tagger (BTagCalibration)
-* - by operating point or reshape bin
-* - by jet parton flavor
-* - by type of measurement
-* - by systematic
-* - by eta bin
-* - as 1D-function dependent of pt or discriminant
-*
-************************************************************/
+ * BTagCalibration
+ *
+ * The 'hierarchy' of stored information is this:
+ * - by tagger (BTagCalibration)
+ *   - by operating point or reshape bin
+ *     - by jet parton flavor
+ *       - by type of measurement
+ *         - by systematic
+ *           - by eta bin
+ *             - as 1D-function dependent of pt or discriminant
+ *
+ ************************************************************/
+
 #include <map>
 #include <vector>
 #include <string>
 #include <istream>
 #include <ostream>
+
+
 class BTagCalibration
 {
 public:
-BTagCalibration() {}
-BTagCalibration(const std::string &tagger);
-BTagCalibration(const std::string &tagger, const std::string &filename);
-~BTagCalibration() {}
-std::string tagger() const {return tagger_;}
-void addEntry(const BTagEntry &entry);
-const std::vector<BTagEntry>& getEntries(const BTagEntry::Parameters &par) const;
-void readCSV(std::istream &s);
-void readCSV(const std::string &s);
-void makeCSV(std::ostream &s) const;
-std::string makeCSV() const;
+  BTagCalibration() {}
+  BTagCalibration(const std::string &tagger);
+  BTagCalibration(const std::string &tagger, const std::string &filename);
+  ~BTagCalibration() {}
+
+  std::string tagger() const {return tagger_;}
+
+  void addEntry(const BTagEntry &entry);
+  const std::vector<BTagEntry>& getEntries(const BTagEntry::Parameters &par) const;
+
+  void readCSV(std::istream &s);
+  void readCSV(const std::string &s);
+  void makeCSV(std::ostream &s) const;
+  std::string makeCSV() const;
+
 protected:
-static std::string token(const BTagEntry::Parameters &par);
-std::string tagger_;
-std::map<std::string, std::vector<BTagEntry> > data_;
+  static std::string token(const BTagEntry::Parameters &par);
+
+  std::string tagger_;
+  std::map<std::string, std::vector<BTagEntry> > data_;
+
 };
-#endif // BTagCalibration_H
+
+#endif  // BTagCalibration_H
+
+
 #ifndef BTagCalibrationReader_H
 #define BTagCalibrationReader_H
+
 /**
-* BTagCalibrationReader
-*
-* Helper class to pull out a specific set of BTagEntry's out of a
-* BTagCalibration. TF1 functions are set up at initialization time.
-*
-************************************************************/
+ * BTagCalibrationReader
+ *
+ * Helper class to pull out a specific set of BTagEntry's out of a
+ * BTagCalibration. TF1 functions are set up at initialization time.
+ *
+ ************************************************************/
+
 #include <memory>
 #include <string>
+
+
+
 class BTagCalibrationReader
 {
 public:
-class BTagCalibrationReaderImpl;
-BTagCalibrationReader() {}
-BTagCalibrationReader(BTagEntry::OperatingPoint op,
-const std::string & sysType="central",
-const std::vector<std::string> & otherSysTypes={});
-void load(const BTagCalibration & c,
-BTagEntry::JetFlavor jf,
-const std::string & measurementType="comb");
-double eval(BTagEntry::JetFlavor jf,
-float eta,
-float pt,
-float discr=0.) const;
-double eval_auto_bounds(const std::string & sys,
-BTagEntry::JetFlavor jf,
-float eta,
-float pt,
-float discr=0.) const;
-std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
-float eta,
-float discr=0.) const;
+  class BTagCalibrationReaderImpl;
+
+  BTagCalibrationReader() {}
+  BTagCalibrationReader(BTagEntry::OperatingPoint op,
+                        const std::string & sysType="central",
+                        const std::vector<std::string> & otherSysTypes={});
+
+  void load(const BTagCalibration & c,
+            BTagEntry::JetFlavor jf,
+            const std::string & measurementType="comb");
+
+  double eval(BTagEntry::JetFlavor jf,
+              float eta,
+              float pt,
+              float discr=0.) const;
+
+  double eval_auto_bounds(const std::string & sys,
+                          BTagEntry::JetFlavor jf,
+                          float eta,
+                          float pt,
+                          float discr=0.) const;
+
+  std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
+                                     float eta,
+                                     float discr=0.) const;
+
 protected:
-std::shared_ptr<BTagCalibrationReaderImpl> pimpl;
+  std::shared_ptr<BTagCalibrationReaderImpl> pimpl;
 };
-#endif // BTagCalibrationReader_H
+
+
+#endif  // BTagCalibrationReader_H
 
 

--- a/interface/BTagFilterOperator.h
+++ b/interface/BTagFilterOperator.h
@@ -20,39 +20,75 @@ constexpr auto CMVA_name = "pfCombinedMVAV2BJetTags";
       double d_value_;
       std::size_t min_number_;
       bool isdata_;
+      bool per_jet_sf_;
 
-    // Load BTagSF
-      const BTagCalibration calibCSV;
-      const BTagCalibration calibCMVA;
-      BTagEntry::JetFlavor jf = BTagEntry::FLAV_UDSG;
-      BTagEntry::JetFlavor jfPrev = BTagEntry::FLAV_UDSG;
-    // BTagSF options
-      BTagCalibrationReader btcr = BTagCalibrationReader(BTagEntry::OP_RESHAPING, "central", {});
-      std::string BTagSFmode = "iterativefit";
+
+      // get short disc name
+      std::map < std::string, std::string> s_name_map; 
+      // get flavour from hadronFlavour
+      std::map < int , BTagEntry::JetFlavor > flavour_map; 
+      // systematics to take into account per flavour
+      std::map< BTagEntry::JetFlavor, std::vector<std::string>> syst_map; 
+      // Load BTagSF
+      BTagCalibration btcalib;
+      // BTagSF options
+      std::map<std::string, BTagCalibrationReader> cr_map;
+      std::string sf_mode = "iterativefit";
          
-      BTagFilterOperator( std::string disc, double d_value, std::size_t min_number , bool isdata,
-                          const std::string & data_path ) :
+      BTagFilterOperator( std::string disc, double d_value,
+                          std::size_t min_number , bool isdata,
+                          std::string data_path, bool per_jet_sf = true ) :
        disc_(disc),
        d_value_(d_value),
        min_number_(min_number),
        isdata_(isdata),
-       calibCSV("CSVv2", data_path+ "CSVv2_ichep.csv"),
-       calibCMVA("CMVAv2", data_path+"cMVAv2_ichep.csv")
+       per_jet_sf_(per_jet_sf)
        {
-         if(disc_ == CSV_name){
-           btcr.load(calibCSV,BTagEntry::FLAV_B, BTagSFmode);
-           btcr.load(calibCSV,BTagEntry::FLAV_C, BTagSFmode);
-           btcr.load(calibCSV,BTagEntry::FLAV_UDSG, BTagSFmode);
-         }
-         else if (disc_ == CMVA_name){
-           btcr.load(calibCMVA,BTagEntry::FLAV_B, BTagSFmode);
-           btcr.load(calibCMVA,BTagEntry::FLAV_C, BTagSFmode);
-           btcr.load(calibCMVA,BTagEntry::FLAV_UDSG, BTagSFmode);
-         }
-         else {
-           std::cout << "ERROR: wrong btag discr" << std::endl;
-         }
-       }
+
+         s_name_map = {{"pfCombinedInclusiveSecondaryVertexV2BJetTags", "CSVv2"},
+                       {"pfCombinedMVAV2BJetTags", "cMVAv2"}};
+       
+         flavour_map = {{5, BTagEntry::FLAV_B},
+                        {4, BTagEntry::FLAV_C},
+                        {0, BTagEntry::FLAV_UDSG}};
+
+         syst_map = {{BTagEntry::FLAV_B, {"up_jes","down_jes",
+                                          "up_lf","down_lf",
+                                          "up_hfstats1", "down_hfstats1",
+                                          "up_hfstats2", "down_hfstats2"}},
+                    {BTagEntry::FLAV_C, {"up_cferr1","down_cferr1",
+                                         "up_cferr2", "down_cferr2"}},
+                    {BTagEntry::FLAV_UDSG, {"up_jes","down_jes",
+                                            "up_hf","down_hf",
+                                            "up_lfstats1", "down_lfstats1",
+                                            "up_lfstats2", "down_lfstats2"}}};
+
+         btcalib = BTagCalibration(s_name_map.at(disc), data_path+s_name_map.at(disc)+"_ichep.csv");
+
+         cr_map.emplace("central",
+                        BTagCalibrationReader{BTagEntry::OP_RESHAPING,
+                                              "central", {}});
+         for (const auto & kv : flavour_map) 
+           cr_map.at("central").load(btcalib,kv.second, sf_mode);
+         // for every flavour
+         for (const auto & kv : syst_map) {
+           auto & syst_vector = kv.second;
+           // for every systematic relevant per flavour
+           for (const auto & syst : syst_vector) {
+             auto it = cr_map.find(syst);
+             if (it ==cr_map.end()) {
+               // return iterator as firt pair element
+               it = cr_map.emplace(syst,
+                                   BTagCalibrationReader{BTagEntry::OP_RESHAPING,
+                                                         syst, {}})
+                                  .first;
+             }
+             // load calibration for this flavour and reader
+             it->second.load(btcalib,kv.first, sf_mode);
+           }
+        }
+      }
+
       virtual ~BTagFilterOperator() {}
 
       virtual bool process( EventClass & ev ) {
@@ -64,18 +100,59 @@ constexpr auto CMVA_name = "pfCombinedMVAV2BJetTags";
         for (std::size_t i=0; i < min_number_; i++) {
             if(ev.jets_.at(i).disc(disc_) < d_value_) return false;
         }
-        // compute BTagSF on all objects in acc - NOTE: needed because we sorted in btag
-        float w_btag = 1.0;
-        for (std::size_t i=0; i < ev.jets_.size(); i++) {
+
+        // weight_map to save event weights BTagSF on
+        std::map<std::string, float> weight_map;
+        // inititialize all weights to 1.0
+        weight_map["BTagWeight"] = 1.0;
+        for (const auto & kv : syst_map) {
+           for (const auto & syst : kv.second) {
+             // at(syst) would return exception when no element exists
+             weight_map["BTagWeight_"+syst] = 1.0;
+           }
+        }
+
+        for (auto & jet : ev.jets_) {
           if(!isdata_) {
-            if (ev.jets_.at(i).hadronFlavour_ == 5)      jf = BTagEntry::FLAV_B;
-            else if (ev.jets_.at(i).hadronFlavour_ == 4) jf = BTagEntry::FLAV_C;
-            else if (ev.jets_.at(i).hadronFlavour_ == 0) jf = BTagEntry::FLAV_UDSG;
-            w_btag *= btcr.eval(jf, ev.jets_.at(i).p4_.Eta(), ev.jets_.at(i).p4_.Pt(), ev.jets_.at(i).disc(disc_));
+            auto jet_flavour = flavour_map.at(jet.hadronFlavour());
+            auto jet_eta = jet.eta();
+            auto jet_pt = jet.pt();
+            auto jet_disc = jet.disc(disc_);
+             
+            
+            auto central_sf = cr_map.at("central")
+                                    .eval(jet_flavour, jet_eta,
+                                          jet_pt, jet_disc);
+
+            // range checks to avoid sf = 0
+            if (std::abs(jet_eta) > 2.4) central_sf = 1.0;
+            if (jet_pt < 20) central_sf = 1.0;
+            if (jet_pt > 1000) central_sf = 1.0;
+
+            weight_map.at("BTagWeight") *= central_sf;            
+            if (per_jet_sf_) jet.discs_.emplace_back("BTagWeight",central_sf);
+
+            for (const auto & syst : syst_map.at(jet_flavour)) {
+              auto syst_sf = cr_map.at(syst)
+                                   .eval(jet_flavour, jet_eta,
+                                         jet_pt, jet_disc);
+
+              // range checks to avoid sf = 0
+              if (std::abs(jet_eta) > 2.4) syst_sf = 1.0;
+              if (jet_pt < 20) syst_sf = 1.0;
+              if (jet_pt > 1000) syst_sf = 1.0;
+
+              weight_map.at("BTagWeight_"+syst) *= syst_sf;
+              if (per_jet_sf_) jet.discs_.emplace_back("BTagWeight_"+syst,central_sf);
+            }
+
           }
         }
-        // add weight to event info
-        ev.eventInfo_.weightPairs_.emplace_back("BTagWeight",w_btag);
+
+        // add weights to event info
+        for (const auto & weight_pair : weight_map) {
+          ev.eventInfo_.weightPairs_.emplace_back(weight_pair);
+        }
 
         return true;
       }

--- a/src/BTagCalibrationStandalone.cpp
+++ b/src/BTagCalibrationStandalone.cpp
@@ -3,559 +3,632 @@
 #include <exception>
 #include <algorithm>
 #include <sstream>
+
+
 BTagEntry::Parameters::Parameters(
-OperatingPoint op,
-std::string measurement_type,
-std::string sys_type,
-JetFlavor jf,
-float eta_min,
-float eta_max,
-float pt_min,
-float pt_max,
-float discr_min,
-float discr_max
+  OperatingPoint op,
+  std::string measurement_type,
+  std::string sys_type,
+  JetFlavor jf,
+  float eta_min,
+  float eta_max,
+  float pt_min,
+  float pt_max,
+  float discr_min,
+  float discr_max
 ):
-operatingPoint(op),
-measurementType(measurement_type),
-sysType(sys_type),
-jetFlavor(jf),
-etaMin(eta_min),
-etaMax(eta_max),
-ptMin(pt_min),
-ptMax(pt_max),
-discrMin(discr_min),
-discrMax(discr_max)
+  operatingPoint(op),
+  measurementType(measurement_type),
+  sysType(sys_type),
+  jetFlavor(jf),
+  etaMin(eta_min),
+  etaMax(eta_max),
+  ptMin(pt_min),
+  ptMax(pt_max),
+  discrMin(discr_min),
+  discrMax(discr_max)
 {
-std::transform(measurementType.begin(), measurementType.end(),
-measurementType.begin(), ::tolower);
-std::transform(sysType.begin(), sysType.end(),
-sysType.begin(), ::tolower);
+  std::transform(measurementType.begin(), measurementType.end(),
+                 measurementType.begin(), ::tolower);
+  std::transform(sysType.begin(), sysType.end(),
+                 sysType.begin(), ::tolower);
 }
+
 BTagEntry::BTagEntry(const std::string &csvLine)
 {
-// make tokens
-std::stringstream buff(csvLine);
-std::vector<std::string> vec;
-std::string token;
-while (std::getline(buff, token, ","[0])) {
-token = BTagEntry::trimStr(token);
-if (token.empty()) {
-continue;
-}
-vec.push_back(token);
-}
-if (vec.size() != 11) {
+  // make tokens
+  std::stringstream buff(csvLine);
+  std::vector<std::string> vec;
+  std::string token;
+  while (std::getline(buff, token, ","[0])) {
+    token = BTagEntry::trimStr(token);
+    if (token.empty()) {
+      continue;
+    }
+    vec.push_back(token);
+  }
+  if (vec.size() != 11) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Invalid csv line; num tokens != 11: "
-<< csvLine;
+          << "Invalid csv line; num tokens != 11: "
+          << csvLine;
 throw std::exception();
-}
-// clean string values
-char chars[] = " \"\n";
-for (unsigned int i = 0; i < strlen(chars); ++i) {
-vec[1].erase(remove(vec[1].begin(),vec[1].end(),chars[i]),vec[1].end());
-vec[2].erase(remove(vec[2].begin(),vec[2].end(),chars[i]),vec[2].end());
-vec[10].erase(remove(vec[10].begin(),vec[10].end(),chars[i]),vec[10].end());
-}
-// make formula
-formula = vec[10];
-TF1 f1("", formula.c_str()); // compile formula to check validity
-if (f1.IsZombie()) {
+  }
+
+  // clean string values
+  char chars[] = " \"\n";
+  for (unsigned int i = 0; i < strlen(chars); ++i) {
+    vec[1].erase(remove(vec[1].begin(),vec[1].end(),chars[i]),vec[1].end());
+    vec[2].erase(remove(vec[2].begin(),vec[2].end(),chars[i]),vec[2].end());
+    vec[10].erase(remove(vec[10].begin(),vec[10].end(),chars[i]),vec[10].end());
+  }
+
+  // make formula
+  formula = vec[10];
+  TF1 f1("", formula.c_str());  // compile formula to check validity
+  if (f1.IsZombie()) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Invalid csv line; formula does not compile: "
-<< csvLine;
+          << "Invalid csv line; formula does not compile: "
+          << csvLine;
 throw std::exception();
-}
-// make parameters
-unsigned op = stoi(vec[0]);
-if (op > 3) {
+  }
+
+  // make parameters
+  unsigned op = stoi(vec[0]);
+  if (op > 3) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Invalid csv line; OperatingPoint > 3: "
-<< csvLine;
+          << "Invalid csv line; OperatingPoint > 3: "
+          << csvLine;
 throw std::exception();
-}
-unsigned jf = stoi(vec[3]);
-if (jf > 2) {
+  }
+  unsigned jf = stoi(vec[3]);
+  if (jf > 2) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Invalid csv line; JetFlavor > 2: "
-<< csvLine;
+          << "Invalid csv line; JetFlavor > 2: "
+          << csvLine;
 throw std::exception();
+  }
+  params = BTagEntry::Parameters(
+    BTagEntry::OperatingPoint(op),
+    vec[1],
+    vec[2],
+    BTagEntry::JetFlavor(jf),
+    stof(vec[4]),
+    stof(vec[5]),
+    stof(vec[6]),
+    stof(vec[7]),
+    stof(vec[8]),
+    stof(vec[9])
+  );
 }
-params = BTagEntry::Parameters(
-BTagEntry::OperatingPoint(op),
-vec[1],
-vec[2],
-BTagEntry::JetFlavor(jf),
-stof(vec[4]),
-stof(vec[5]),
-stof(vec[6]),
-stof(vec[7]),
-stof(vec[8]),
-stof(vec[9])
-);
-}
+
 BTagEntry::BTagEntry(const std::string &func, BTagEntry::Parameters p):
-formula(func),
-params(p)
+  formula(func),
+  params(p)
 {
-TF1 f1("", formula.c_str()); // compile formula to check validity
-if (f1.IsZombie()) {
+  TF1 f1("", formula.c_str());  // compile formula to check validity
+  if (f1.IsZombie()) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Invalid func string; formula does not compile: "
-<< func;
+          << "Invalid func string; formula does not compile: "
+          << func;
 throw std::exception();
+  }
 }
-}
+
 BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p):
-formula(std::string(func->GetExpFormula("p").Data())),
-params(p)
+  formula(std::string(func->GetExpFormula("p").Data())),
+  params(p)
 {
-if (func->IsZombie()) {
+  if (func->IsZombie()) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Invalid TF1 function; function is zombie: "
-<< func->GetName();
+          << "Invalid TF1 function; function is zombie: "
+          << func->GetName();
 throw std::exception();
+  }
 }
-}
+
 // Creates chained step functions like this:
 // "<prevous_bin> : x<bin_high_bound ? bin_value : <next_bin>"
 // e.g. "x<0 ? 1 : x<1 ? 2 : x<2 ? 3 : 4"
 std::string th1ToFormulaLin(const TH1* hist) {
-int nbins = hist->GetNbinsX();
-TAxis const* axis = hist->GetXaxis();
-std::stringstream buff;
-buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : "; // default value
-for (int i=1; i<nbins+1; ++i) {
-char tmp_buff[50];
-sprintf(tmp_buff,
-"x<%g ? %g : ", // %g is the smaller one of %e or %f
-axis->GetBinUpEdge(i),
-hist->GetBinContent(i));
-buff << tmp_buff;
+  int nbins = hist->GetNbinsX();
+  TAxis const* axis = hist->GetXaxis();
+  std::stringstream buff;
+  buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : ";  // default value
+  for (int i=1; i<nbins+1; ++i) {
+    char tmp_buff[50];
+    sprintf(tmp_buff,
+            "x<%g ? %g : ",  // %g is the smaller one of %e or %f
+            axis->GetBinUpEdge(i),
+            hist->GetBinContent(i));
+    buff << tmp_buff;
+  }
+  buff << 0.;  // default value
+  return buff.str();
 }
-buff << 0.; // default value
-return buff.str();
-}
+
 // Creates step functions making a binary search tree:
 // "x<mid_bin_bound ? (<left side tree>) : (<right side tree>)"
 // e.g. "x<2 ? (x<1 ? (x<0 ? 0:0.1) : (1)) : (x<4 ? (x<3 ? 2:3) : (0))"
 std::string th1ToFormulaBinTree(const TH1* hist, int start=0, int end=-1) {
-if (end == -1) { // initialize
-start = 0.;
-end = hist->GetNbinsX()+1;
-TH1* h2 = (TH1*) hist->Clone();
-h2->SetBinContent(start, 0); // kill underflow
-h2->SetBinContent(end, 0); // kill overflow
-std::string res = th1ToFormulaBinTree(h2, start, end);
-delete h2;
-return res;
+  if (end == -1) {                      // initialize
+    start = 0.;
+    end = hist->GetNbinsX()+1;
+    TH1* h2 = (TH1*) hist->Clone();
+    h2->SetBinContent(start, 0);  // kill underflow
+    h2->SetBinContent(end, 0);    // kill overflow
+    std::string res = th1ToFormulaBinTree(h2, start, end);
+    delete h2;
+    return res;
+  }
+  if (start == end) {                   // leave is reached
+    char tmp_buff[20];
+    sprintf(tmp_buff, "%g", hist->GetBinContent(start));
+    return std::string(tmp_buff);
+  }
+  if (start == end - 1) {               // no parenthesis for neighbors
+    char tmp_buff[70];
+    sprintf(tmp_buff,
+            "x<%g ? %g:%g",
+            hist->GetXaxis()->GetBinUpEdge(start),
+            hist->GetBinContent(start),
+            hist->GetBinContent(end));
+    return std::string(tmp_buff);
+  }
+
+  // top-down recursion
+  std::stringstream buff;
+  int mid = (end-start)/2 + start;
+  char tmp_buff[25];
+  sprintf(tmp_buff,
+          "x<%g ? (",
+          hist->GetXaxis()->GetBinUpEdge(mid));
+  buff << tmp_buff
+       << th1ToFormulaBinTree(hist, start, mid)
+       << ") : ("
+       << th1ToFormulaBinTree(hist, mid+1, end)
+       << ")";
+  return buff.str();
 }
-if (start == end) { // leave is reached
-char tmp_buff[20];
-sprintf(tmp_buff, "%g", hist->GetBinContent(start));
-return std::string(tmp_buff);
-}
-if (start == end - 1) { // no parenthesis for neighbors
-char tmp_buff[70];
-sprintf(tmp_buff,
-"x<%g ? %g:%g",
-hist->GetXaxis()->GetBinUpEdge(start),
-hist->GetBinContent(start),
-hist->GetBinContent(end));
-return std::string(tmp_buff);
-}
-// top-down recursion
-std::stringstream buff;
-int mid = (end-start)/2 + start;
-char tmp_buff[25];
-sprintf(tmp_buff,
-"x<%g ? (",
-hist->GetXaxis()->GetBinUpEdge(mid));
-buff << tmp_buff
-<< th1ToFormulaBinTree(hist, start, mid)
-<< ") : ("
-<< th1ToFormulaBinTree(hist, mid+1, end)
-<< ")";
-return buff.str();
-}
+
 BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
-params(p)
+  params(p)
 {
-int nbins = hist->GetNbinsX();
-TAxis const* axis = hist->GetXaxis();
-// overwrite bounds with histo values
-if (params.operatingPoint == BTagEntry::OP_RESHAPING) {
-params.discrMin = axis->GetBinLowEdge(1);
-params.discrMax = axis->GetBinUpEdge(nbins);
-} else {
-params.ptMin = axis->GetBinLowEdge(1);
-params.ptMax = axis->GetBinUpEdge(nbins);
-}
-// balanced full binary tree height = ceil(log(2*n_leaves)/log(2))
-// breakes even around 10, but lower values are more propable in pt-spectrum
-if (nbins < 15) {
-formula = th1ToFormulaLin(hist);
-} else {
-formula = th1ToFormulaBinTree(hist);
-}
-// compile formula to check validity
-TF1 f1("", formula.c_str());
-if (f1.IsZombie()) {
+  int nbins = hist->GetNbinsX();
+  TAxis const* axis = hist->GetXaxis();
+
+  // overwrite bounds with histo values
+  if (params.operatingPoint == BTagEntry::OP_RESHAPING) {
+    params.discrMin = axis->GetBinLowEdge(1);
+    params.discrMax = axis->GetBinUpEdge(nbins);
+  } else {
+    params.ptMin = axis->GetBinLowEdge(1);
+    params.ptMax = axis->GetBinUpEdge(nbins);
+  }
+
+  // balanced full binary tree height = ceil(log(2*n_leaves)/log(2))
+  // breakes even around 10, but lower values are more propable in pt-spectrum
+  if (nbins < 15) {
+    formula = th1ToFormulaLin(hist);
+  } else {
+    formula = th1ToFormulaBinTree(hist);
+  }
+
+  // compile formula to check validity
+  TF1 f1("", formula.c_str());
+  if (f1.IsZombie()) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Invalid histogram; formula does not compile (>150 bins?): "
-<< hist->GetName();
+          << "Invalid histogram; formula does not compile (>150 bins?): "
+          << hist->GetName();
 throw std::exception();
+  }
 }
-}
+
 std::string BTagEntry::makeCSVHeader()
 {
-return "OperatingPoint, "
-"measurementType, "
-"sysType, "
-"jetFlavor, "
-"etaMin, "
-"etaMax, "
-"ptMin, "
-"ptMax, "
-"discrMin, "
-"discrMax, "
-"formula \n";
+  return "OperatingPoint, "
+         "measurementType, "
+         "sysType, "
+         "jetFlavor, "
+         "etaMin, "
+         "etaMax, "
+         "ptMin, "
+         "ptMax, "
+         "discrMin, "
+         "discrMax, "
+         "formula \n";
 }
+
 std::string BTagEntry::makeCSVLine() const
 {
-std::stringstream buff;
-buff << params.operatingPoint
-<< ", " << params.measurementType
-<< ", " << params.sysType
-<< ", " << params.jetFlavor
-<< ", " << params.etaMin
-<< ", " << params.etaMax
-<< ", " << params.ptMin
-<< ", " << params.ptMax
-<< ", " << params.discrMin
-<< ", " << params.discrMax
-<< ", \"" << formula
-<< "\" \n";
-return buff.str();
+  std::stringstream buff;
+  buff << params.operatingPoint
+       << ", " << params.measurementType
+       << ", " << params.sysType
+       << ", " << params.jetFlavor
+       << ", " << params.etaMin
+       << ", " << params.etaMax
+       << ", " << params.ptMin
+       << ", " << params.ptMax
+       << ", " << params.discrMin
+       << ", " << params.discrMax
+       << ", \"" << formula
+       << "\" \n";
+  return buff.str();
 }
+
 std::string BTagEntry::trimStr(std::string str) {
-size_t s = str.find_first_not_of(" \n\r\t");
-size_t e = str.find_last_not_of (" \n\r\t");
-if((std::string::npos == s) || (std::string::npos == e))
-return "";
-else
-return str.substr(s, e-s+1);
+  size_t s = str.find_first_not_of(" \n\r\t");
+  size_t e = str.find_last_not_of (" \n\r\t");
+
+  if((std::string::npos == s) || (std::string::npos == e))
+    return "";
+  else
+    return str.substr(s, e-s+1);
 }
+
+
 #include <fstream>
 #include <sstream>
+
+
+
 BTagCalibration::BTagCalibration(const std::string &taggr):
-tagger_(taggr)
+  tagger_(taggr)
 {}
+
 BTagCalibration::BTagCalibration(const std::string &taggr,
-const std::string &filename):
-tagger_(taggr)
+                                 const std::string &filename):
+  tagger_(taggr)
 {
-std::ifstream ifs(filename);
-if (!ifs.good()) {
+  std::ifstream ifs(filename);
+  if (!ifs.good()) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "input file not available: "
-<< filename;
+          << "input file not available: "
+          << filename;
 throw std::exception();
+  }
+  readCSV(ifs);
+  ifs.close();
 }
-readCSV(ifs);
-ifs.close();
-}
+
 void BTagCalibration::addEntry(const BTagEntry &entry)
 {
-data_[token(entry.params)].push_back(entry);
+  data_[token(entry.params)].push_back(entry);
 }
+
 const std::vector<BTagEntry>& BTagCalibration::getEntries(
-const BTagEntry::Parameters &par) const
+  const BTagEntry::Parameters &par) const
 {
-std::string tok = token(par);
-if (!data_.count(tok)) {
+  std::string tok = token(par);
+  if (!data_.count(tok)) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "(OperatingPoint, measurementType, sysType) not available: "
-<< tok;
+          << "(OperatingPoint, measurementType, sysType) not available: "
+          << tok;
 throw std::exception();
+  }
+  return data_.at(tok);
 }
-return data_.at(tok);
-}
+
 void BTagCalibration::readCSV(const std::string &s)
 {
-std::stringstream buff(s);
-readCSV(buff);
+  std::stringstream buff(s);
+  readCSV(buff);
 }
+
 void BTagCalibration::readCSV(std::istream &s)
 {
-std::string line;
-// firstline might be the header
-getline(s,line);
-if (line.find("OperatingPoint") == std::string::npos) {
-addEntry(BTagEntry(line));
+  std::string line;
+
+  // firstline might be the header
+  getline(s,line);
+  if (line.find("OperatingPoint") == std::string::npos) {
+    addEntry(BTagEntry(line));
+  }
+
+  while (getline(s,line)) {
+    line = BTagEntry::trimStr(line);
+    if (line.empty()) {  // skip empty lines
+      continue;
+    }
+    addEntry(BTagEntry(line));
+  }
 }
-while (getline(s,line)) {
-line = BTagEntry::trimStr(line);
-if (line.empty()) { // skip empty lines
-continue;
-}
-addEntry(BTagEntry(line));
-}
-}
+
 void BTagCalibration::makeCSV(std::ostream &s) const
 {
-s << tagger_ << ";" << BTagEntry::makeCSVHeader();
-for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i
-= data_.cbegin(); i != data_.cend(); ++i) {
-const std::vector<BTagEntry> &vec = i->second;
-for (std::vector<BTagEntry>::const_iterator j
-= vec.cbegin(); j != vec.cend(); ++j) {
-s << j->makeCSVLine();
+  s << tagger_ << ";" << BTagEntry::makeCSVHeader();
+  for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i
+           = data_.cbegin(); i != data_.cend(); ++i) {
+    const std::vector<BTagEntry> &vec = i->second;
+    for (std::vector<BTagEntry>::const_iterator j
+             = vec.cbegin(); j != vec.cend(); ++j) {
+      s << j->makeCSVLine();
+    }
+  }
 }
-}
-}
+
 std::string BTagCalibration::makeCSV() const
 {
-std::stringstream buff;
-makeCSV(buff);
-return buff.str();
+  std::stringstream buff;
+  makeCSV(buff);
+  return buff.str();
 }
+
 std::string BTagCalibration::token(const BTagEntry::Parameters &par)
 {
-std::stringstream buff;
-buff << par.operatingPoint << ", "
-<< par.measurementType << ", "
-<< par.sysType;
-return buff.str();
+  std::stringstream buff;
+  buff << par.operatingPoint << ", "
+       << par.measurementType << ", "
+       << par.sysType;
+  return buff.str();
 }
+
+
+
+
 class BTagCalibrationReader::BTagCalibrationReaderImpl
 {
-friend class BTagCalibrationReader;
+  friend class BTagCalibrationReader;
+
 public:
-struct TmpEntry {
-float etaMin;
-float etaMax;
-float ptMin;
-float ptMax;
-float discrMin;
-float discrMax;
-TF1 func;
-};
+  struct TmpEntry {
+    float etaMin;
+    float etaMax;
+    float ptMin;
+    float ptMax;
+    float discrMin;
+    float discrMax;
+    TF1 func;
+  };
+
 private:
-BTagCalibrationReaderImpl(BTagEntry::OperatingPoint op,
-const std::string & sysType,
-const std::vector<std::string> & otherSysTypes={});
-void load(const BTagCalibration & c,
-BTagEntry::JetFlavor jf,
-std::string measurementType);
-double eval(BTagEntry::JetFlavor jf,
-float eta,
-float pt,
-float discr) const;
-double eval_auto_bounds(const std::string & sys,
-BTagEntry::JetFlavor jf,
-float eta,
-float pt,
-float discr) const;
-std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
-float eta,
-float discr) const;
-BTagEntry::OperatingPoint op_;
-std::string sysType_;
-std::vector<std::vector<TmpEntry> > tmpData_; // first index: jetFlavor
-std::vector<bool> useAbsEta_; // first index: jetFlavor
-std::map<std::string, std::shared_ptr<BTagCalibrationReaderImpl>> otherSysTypeReaders_;
+  BTagCalibrationReaderImpl(BTagEntry::OperatingPoint op,
+                            const std::string & sysType,
+                            const std::vector<std::string> & otherSysTypes={});
+
+  void load(const BTagCalibration & c,
+            BTagEntry::JetFlavor jf,
+            std::string measurementType);
+
+  double eval(BTagEntry::JetFlavor jf,
+              float eta,
+              float pt,
+              float discr) const;
+
+  double eval_auto_bounds(const std::string & sys,
+                          BTagEntry::JetFlavor jf,
+                          float eta,
+                          float pt,
+                          float discr) const;
+
+  std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
+                                     float eta,
+                                     float discr) const;
+
+  BTagEntry::OperatingPoint op_;
+  std::string sysType_;
+  std::vector<std::vector<TmpEntry> > tmpData_;  // first index: jetFlavor
+  std::vector<bool> useAbsEta_;                  // first index: jetFlavor
+  std::map<std::string, std::shared_ptr<BTagCalibrationReaderImpl>> otherSysTypeReaders_;
 };
+
+
 BTagCalibrationReader::BTagCalibrationReaderImpl::BTagCalibrationReaderImpl(
-BTagEntry::OperatingPoint op,
-const std::string & sysType,
-const std::vector<std::string> & otherSysTypes):
-op_(op),
-sysType_(sysType),
-tmpData_(3),
-useAbsEta_(3, true)
+                                             BTagEntry::OperatingPoint op,
+                                             const std::string & sysType,
+                                             const std::vector<std::string> & otherSysTypes):
+  op_(op),
+  sysType_(sysType),
+  tmpData_(3),
+  useAbsEta_(3, true)
 {
-for (const std::string & ost : otherSysTypes) {
-if (otherSysTypeReaders_.count(ost)) {
+  for (const std::string & ost : otherSysTypes) {
+    if (otherSysTypeReaders_.count(ost)) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Every otherSysType should only be given once. Duplicate: "
-<< ost;
+            << "Every otherSysType should only be given once. Duplicate: "
+            << ost;
 throw std::exception();
+    }
+    otherSysTypeReaders_[ost] = std::auto_ptr<BTagCalibrationReaderImpl>(
+        new BTagCalibrationReaderImpl(op, ost)
+    );
+  }
 }
-otherSysTypeReaders_[ost] = std::auto_ptr<BTagCalibrationReaderImpl>(
-new BTagCalibrationReaderImpl(op, ost)
-);
-}
-}
+
 void BTagCalibrationReader::BTagCalibrationReaderImpl::load(
-const BTagCalibration & c,
-BTagEntry::JetFlavor jf,
-std::string measurementType)
+                                             const BTagCalibration & c,
+                                             BTagEntry::JetFlavor jf,
+                                             std::string measurementType)
 {
-if (tmpData_[jf].size()) {
+  if (tmpData_[jf].size()) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "Data for this jet-flavor is already loaded: "
-<< jf;
+          << "Data for this jet-flavor is already loaded: "
+          << jf;
 throw std::exception();
+  }
+
+  BTagEntry::Parameters params(op_, measurementType, sysType_);
+  const std::vector<BTagEntry> &entries = c.getEntries(params);
+
+  for (const auto &be : entries) {
+    if (be.params.jetFlavor != jf) {
+      continue;
+    }
+
+    TmpEntry te;
+    te.etaMin = be.params.etaMin;
+    te.etaMax = be.params.etaMax;
+    te.ptMin = be.params.ptMin;
+    te.ptMax = be.params.ptMax;
+    te.discrMin = be.params.discrMin;
+    te.discrMax = be.params.discrMax;
+
+    if (op_ == BTagEntry::OP_RESHAPING) {
+      te.func = TF1("", be.formula.c_str(),
+                    be.params.discrMin, be.params.discrMax);
+    } else {
+      te.func = TF1("", be.formula.c_str(),
+                    be.params.ptMin, be.params.ptMax);
+    }
+
+    tmpData_[be.params.jetFlavor].push_back(te);
+    if (te.etaMin < 0) {
+      useAbsEta_[be.params.jetFlavor] = false;
+    }
+  }
+
+  for (auto & p : otherSysTypeReaders_) {
+    p.second->load(c, jf, measurementType);
+  }
 }
-BTagEntry::Parameters params(op_, measurementType, sysType_);
-const std::vector<BTagEntry> &entries = c.getEntries(params);
-for (const auto &be : entries) {
-if (be.params.jetFlavor != jf) {
-continue;
-}
-TmpEntry te;
-te.etaMin = be.params.etaMin;
-te.etaMax = be.params.etaMax;
-te.ptMin = be.params.ptMin;
-te.ptMax = be.params.ptMax;
-te.discrMin = be.params.discrMin;
-te.discrMax = be.params.discrMax;
-if (op_ == BTagEntry::OP_RESHAPING) {
-te.func = TF1("", be.formula.c_str(),
-be.params.discrMin, be.params.discrMax);
-} else {
-te.func = TF1("", be.formula.c_str(),
-be.params.ptMin, be.params.ptMax);
-}
-tmpData_[be.params.jetFlavor].push_back(te);
-if (te.etaMin < 0) {
-useAbsEta_[be.params.jetFlavor] = false;
-}
-}
-for (auto & p : otherSysTypeReaders_) {
-p.second->load(c, jf, measurementType);
-}
-}
+
 double BTagCalibrationReader::BTagCalibrationReaderImpl::eval(
-BTagEntry::JetFlavor jf,
-float eta,
-float pt,
-float discr) const
+                                             BTagEntry::JetFlavor jf,
+                                             float eta,
+                                             float pt,
+                                             float discr) const
 {
-bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
-if (useAbsEta_[jf] && eta < 0) {
-eta = -eta;
+  bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+  if (useAbsEta_[jf] && eta < 0) {
+    eta = -eta;
+  }
+
+  // search linearly through eta, pt and discr ranges and eval
+  // future: find some clever data structure based on intervals
+  const auto &entries = tmpData_.at(jf);
+  for (unsigned i=0; i<entries.size(); ++i) {
+    const auto &e = entries.at(i);
+    if (
+      e.etaMin <= eta && eta < e.etaMax                   // find eta
+      && e.ptMin < pt && pt <= e.ptMax                    // check pt
+    ){
+      if (use_discr) {                                    // discr. reshaping?
+        if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+          return e.func.Eval(discr);
+        }
+      } else {
+        return e.func.Eval(pt);
+      }
+    }
+  }
+
+  return 0.;  // default value
 }
-// search linearly through eta, pt and discr ranges and eval
-// future: find some clever data structure based on intervals
-const auto &entries = tmpData_.at(jf);
-for (unsigned i=0; i<entries.size(); ++i) {
-const auto &e = entries.at(i);
-if (
-e.etaMin <= eta && eta < e.etaMax // find eta
-&& e.ptMin < pt && pt <= e.ptMax // check pt
-){
-if (use_discr) { // discr. reshaping?
-if (e.discrMin <= discr && discr < e.discrMax) { // check discr
-return e.func.Eval(discr);
-}
-} else {
-return e.func.Eval(pt);
-}
-}
-}
-return 0.; // default value
-}
+
 double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
-const std::string & sys,
-BTagEntry::JetFlavor jf,
-float eta,
-float pt,
-float discr) const
+                                             const std::string & sys,
+                                             BTagEntry::JetFlavor jf,
+                                             float eta,
+                                             float pt,
+                                             float discr) const
 {
-auto sf_bounds = min_max_pt(jf, eta, discr);
-float pt_for_eval = pt;
-bool is_out_of_bounds = false;
-if (pt < sf_bounds.first) {
-pt_for_eval = sf_bounds.first + .0001;
-is_out_of_bounds = true;
-} else if (pt > sf_bounds.second) {
-pt_for_eval = sf_bounds.second - .0001;
-is_out_of_bounds = true;
-}
-// get central SF (and maybe return)
-double sf = eval(jf, eta, pt_for_eval, discr);
-if (sys == sysType_) {
-return sf;
-}
-// get sys SF (and maybe return)
-if (!otherSysTypeReaders_.count(sys)) {
+  auto sf_bounds = min_max_pt(jf, eta, discr);
+  float pt_for_eval = pt;
+  bool is_out_of_bounds = false;
+
+  if (pt < sf_bounds.first) {
+    pt_for_eval = sf_bounds.first + .0001;
+    is_out_of_bounds = true;
+  } else if (pt > sf_bounds.second) {
+    pt_for_eval = sf_bounds.second - .0001;
+    is_out_of_bounds = true;
+  }
+
+  // get central SF (and maybe return)
+  double sf = eval(jf, eta, pt_for_eval, discr);
+  if (sys == sysType_) {
+    return sf;
+  }
+
+  // get sys SF (and maybe return)
+  if (!otherSysTypeReaders_.count(sys)) {
 std::cerr << "ERROR in BTagCalibration: "
-<< "sysType not available (maybe not loaded?): "
-<< sys;
+        << "sysType not available (maybe not loaded?): "
+        << sys;
 throw std::exception();
+  }
+  double sf_err = otherSysTypeReaders_.at(sys)->eval(jf, eta, pt_for_eval, discr);
+  if (!is_out_of_bounds) {
+    return sf_err;
+  }
+
+  // double uncertainty on out-of-bounds and return
+  sf_err = sf + 2*(sf_err - sf);
+  return sf_err;
 }
-double sf_err = otherSysTypeReaders_.at(sys)->eval(jf, eta, pt_for_eval, discr);
-if (!is_out_of_bounds) {
-return sf_err;
-}
-// double uncertainty on out-of-bounds and return
-sf_err = sf + 2*(sf_err - sf);
-return sf_err;
-}
+
 std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_max_pt(
-BTagEntry::JetFlavor jf,
-float eta,
-float discr) const
+                                               BTagEntry::JetFlavor jf,
+                                               float eta,
+                                               float discr) const
 {
-bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
-if (useAbsEta_[jf] && eta < 0) {
-eta = -eta;
+  bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+  if (useAbsEta_[jf] && eta < 0) {
+    eta = -eta;
+  }
+
+  const auto &entries = tmpData_.at(jf);
+  float min_pt = -1., max_pt = -1.;
+  for (const auto & e: entries) {
+    if (
+      e.etaMin <= eta && eta < e.etaMax                   // find eta
+    ){
+      if (min_pt < 0.) {                                  // init
+        min_pt = e.ptMin;
+        max_pt = e.ptMax;
+        continue;
+      }
+
+      if (use_discr) {                                    // discr. reshaping?
+        if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+          min_pt = min_pt < e.ptMin ? min_pt : e.ptMin;
+          max_pt = max_pt > e.ptMax ? max_pt : e.ptMax;
+        }
+      } else {
+        min_pt = min_pt < e.ptMin ? min_pt : e.ptMin;
+        max_pt = max_pt > e.ptMax ? max_pt : e.ptMax;
+      }
+    }
+  }
+
+  return std::make_pair(min_pt, max_pt);
 }
-const auto &entries = tmpData_.at(jf);
-float min_pt = -1., max_pt = -1.;
-for (const auto & e: entries) {
-if (
-e.etaMin <= eta && eta < e.etaMax // find eta
-){
-if (min_pt < 0.) { // init
-min_pt = e.ptMin;
-max_pt = e.ptMax;
-continue;
-}
-if (use_discr) { // discr. reshaping?
-if (e.discrMin <= discr && discr < e.discrMax) { // check discr
-min_pt = min_pt < e.ptMin ? min_pt : e.ptMin;
-max_pt = max_pt > e.ptMax ? max_pt : e.ptMax;
-}
-} else {
-min_pt = min_pt < e.ptMin ? min_pt : e.ptMin;
-max_pt = max_pt > e.ptMax ? max_pt : e.ptMax;
-}
-}
-}
-return std::make_pair(min_pt, max_pt);
-}
+
+
 BTagCalibrationReader::BTagCalibrationReader(BTagEntry::OperatingPoint op,
-const std::string & sysType,
-const std::vector<std::string> & otherSysTypes):
-pimpl(new BTagCalibrationReaderImpl(op, sysType, otherSysTypes)) {}
+                                             const std::string & sysType,
+                                             const std::vector<std::string> & otherSysTypes):
+  pimpl(new BTagCalibrationReaderImpl(op, sysType, otherSysTypes)) {}
+
 void BTagCalibrationReader::load(const BTagCalibration & c,
-BTagEntry::JetFlavor jf,
-const std::string & measurementType)
+                                 BTagEntry::JetFlavor jf,
+                                 const std::string & measurementType)
 {
-pimpl->load(c, jf, measurementType);
+  pimpl->load(c, jf, measurementType);
 }
+
 double BTagCalibrationReader::eval(BTagEntry::JetFlavor jf,
-float eta,
-float pt,
-float discr) const
+                                   float eta,
+                                   float pt,
+                                   float discr) const
 {
-return pimpl->eval(jf, eta, pt, discr);
+  return pimpl->eval(jf, eta, pt, discr);
 }
+
 double BTagCalibrationReader::eval_auto_bounds(const std::string & sys,
-BTagEntry::JetFlavor jf,
-float eta,
-float pt,
-float discr) const
+                                               BTagEntry::JetFlavor jf,
+                                               float eta,
+                                               float pt,
+                                               float discr) const
 {
-return pimpl->eval_auto_bounds(sys, jf, eta, pt, discr);
+  return pimpl->eval_auto_bounds(sys, jf, eta, pt, discr);
 }
+
 std::pair<float, float> BTagCalibrationReader::min_max_pt(BTagEntry::JetFlavor jf,
-float eta,
-float discr) const
+                                                          float eta,
+                                                          float discr) const
 {
-return pimpl->min_max_pt(jf, eta, discr);
+  return pimpl->min_max_pt(jf, eta, discr);
 }
+
 


### PR DESCRIPTION
The BTagFilterOperator has been modified to deal with systematic SF
variations. The BTagCalibrationStandalone script have been updated
because they had bad indentation.